### PR TITLE
Changed puzzle placement algorithm.

### DIFF
--- a/src/ChannelServer/World/Dungeons/Dungeon.cs
+++ b/src/ChannelServer/World/Dungeons/Dungeon.cs
@@ -233,7 +233,7 @@ namespace Aura.Channel.World.Dungeons
 					catch (PuzzleException e)
 					{
 						sections[section].Puzzles.Remove(puzzle);
-						Log.Debug("Section {0}, puzzle '{1}' : {2}", section, scriptName, e.Message);
+						Log.Debug("Floor {0} Section {1}, puzzle '{2}' : {3}", iFloor, section, scriptName, e.Message);
 					}
 				}
 			}

--- a/src/ChannelServer/World/Dungeons/Generation/RoomTrait.cs
+++ b/src/ChannelServer/World/Dungeons/Generation/RoomTrait.cs
@@ -73,6 +73,8 @@ namespace Aura.Channel.World.Dungeons.Generation
 			this.isReserved = false;
 			this.PuzzleDoors = new Door[] {null, null, null, null };
 			this.ReservedDoor = new bool[] { false, false, false, false };
+			this.RoomType = RoomType.None;
+			this.RoomIndex = -1;
 		}
 
 		public void SetNeighbor(int direction, RoomTrait room)

--- a/src/ChannelServer/World/Dungeons/Puzzles/PuzzlePlace.cs
+++ b/src/ChannelServer/World/Dungeons/Puzzles/PuzzlePlace.cs
@@ -111,7 +111,8 @@ namespace Aura.Channel.World.Dungeons.Puzzles
 		private void AddDoor(int direction, DungeonBlockType doorType)
 		{
 			var door = _room.GetPuzzleDoor(direction);
-			if (door != null)
+			// We'll create new door and replace if we want locked door instead of normal one here
+			if (door != null && doorType == DungeonBlockType.Door)
 			{
 				this.Doors[direction] = door;
 				return;


### PR DESCRIPTION
Floors devided into sections more fairly.
Locked places can be added right before chest rooms.
First place can be used as self-locked place now.
DungeonFloorSection.GetLock will return only places that can have unlocks (if it's not a self-lock).
Sections with only one place on critical path and subpath can be used for chest room with locked place now.