### PR TITLE
Changed 'defended' checks.

### DIFF
--- a/src/ChannelServer/Skills/Combat/CombatMastery.cs
+++ b/src/ChannelServer/Skills/Combat/CombatMastery.cs
@@ -123,7 +123,7 @@ namespace Aura.Channel.Skills.Combat
 				// Evaluate caused damage
 				if (!target.IsDead)
 				{
-					if (tAction.Flags != CombatActionType.Defended)
+					if (tAction.SkillId != SkillId.Defense)
 					{
 						target.Stability -= this.GetStabilityReduction(attacker, weapon) / maxHits;
 
@@ -164,7 +164,7 @@ namespace Aura.Channel.Skills.Combat
 				}
 
 				// Set stun time
-				if (tAction.Flags != CombatActionType.Defended)
+				if (tAction.SkillId != SkillId.Defense)
 				{
 					aAction.Stun = GetAttackerStun(attacker, weapon, tAction.IsKnockBack && skill.Info.Id != SkillId.FinalHit);
 					tAction.Stun = GetTargetStun(attacker, weapon, tAction.IsKnockBack);

--- a/src/ChannelServer/Skills/Combat/Windmill.cs
+++ b/src/ChannelServer/Skills/Combat/Windmill.cs
@@ -150,7 +150,7 @@ namespace Aura.Channel.Skills.Combat
 				ManaShield.Handle(target, ref damage, tAction);
 
 				// Clean Hit if not defended nor critical
-				if (!tAction.Is(CombatActionType.Defended) && !tAction.Has(TargetOptions.Critical))
+				if (tAction.SkillId != SkillId.Defense && !tAction.Has(TargetOptions.Critical))
 					tAction.Set(TargetOptions.CleanHit);
 
 				// Take damage if any is left
@@ -160,7 +160,7 @@ namespace Aura.Channel.Skills.Combat
 				// Finish if dead, knock down if not defended
 				if (target.IsDead)
 					tAction.Set(TargetOptions.KnockDownFinish);
-				else if (!tAction.Is(CombatActionType.Defended))
+				else if (tAction.SkillId != SkillId.Defense)
 					tAction.Set(TargetOptions.KnockDown);
 
 				// Anger Management
@@ -170,7 +170,7 @@ namespace Aura.Channel.Skills.Combat
 				// Stun & knock back
 				aAction.Stun = CombatMastery.GetAttackerStun(attacker.AverageKnockCount, attacker.AverageAttackSpeed, true);
 
-				if (!tAction.Is(CombatActionType.Defended))
+				if (tAction.SkillId != SkillId.Defense)
 				{
 					tAction.Stun = CombatMastery.GetTargetStun(attacker.AverageKnockCount, attacker.AverageAttackSpeed, true);
 					target.Stability = Creature.MinStability;


### PR DESCRIPTION
As CombatActionType.Defended is set of flags that has little to do with "defended" and that check was broken with modified `CombatAction.Is` - I changed those checks, fixing windmill among other things.