### PR TITLE
Added Unlimited Dyes Configuration Option

### DIFF
--- a/src/ChannelServer/Skills/Hidden/Dye.cs
+++ b/src/ChannelServer/Skills/Hidden/Dye.cs
@@ -169,7 +169,8 @@ namespace Aura.Channel.Skills.Hidden
 		private void DyeSuccess(Creature creature)
 		{
 			// Remove dye
-			creature.Inventory.Decrement(creature.Temp.SkillItem2);
+			if (!ChannelServer.Instance.Conf.World.UnlimitedDyes)
+				creature.Inventory.Decrement(creature.Temp.SkillItem2);
 
 			// Update item color
 			Send.ItemUpdate(creature, creature.Temp.SkillItem1);

--- a/src/ChannelServer/Util/Configuration/Files/World.cs
+++ b/src/ChannelServer/Util/Configuration/Files/World.cs
@@ -36,6 +36,7 @@ namespace Aura.Channel.Util.Configuration.Files
 		public bool NoDurabilityLoss { get; protected set; }
 		public bool UnlimitedUpgrades { get; protected set; }
 		public bool UncapProficiency { get; protected set; }
+		public bool UnlimitedDyes { get; protected set; }
 
 		public TimeSpan RebirthTime { get; protected set; }
 
@@ -79,6 +80,7 @@ namespace Aura.Channel.Util.Configuration.Files
 			this.NoDurabilityLoss = this.GetBool("no_durability_loss", false);
 			this.UnlimitedUpgrades = this.GetBool("unlimited_upgrades", false);
 			this.UncapProficiency = this.GetBool("uncap_proficiency", false);
+			this.UnlimitedDyes = this.GetBool("unlimited_dyes", false);
 
 			this.RebirthTime = TimeSpan.FromDays(this.GetInt("rebirth_time", 6));
 

--- a/system/conf/world/items.conf
+++ b/system/conf/world/items.conf
@@ -15,4 +15,7 @@ unlimited_upgrades: no
 // Enables collecting proficiency till 255 (instead of 100)
 uncap_proficiency: no
 
+// Dyes do not disappear after use
+unlimited_dyes: no
+
 include "/user/conf/world/items.conf"


### PR DESCRIPTION
Adds configuration in items.conf that disables inventory removal of dyes
upon use.