### PR TITLE
Added system message text wrapping.

### DIFF
--- a/src/ChannelServer/Network/Sending/Send.Messages.cs
+++ b/src/ChannelServer/Network/Sending/Send.Messages.cs
@@ -41,15 +41,21 @@ namespace Aura.Channel.Network.Sending
 		public static void System_Broadcast(string from, string format, params object[] args)
 		{
 			var packet = new Packet(Op.Chat, MabiId.Broadcast);
-			packet.PutByte(0);
-			packet.PutString("<{0}>", from);
-			packet.PutString(format, args);
-			packet.PutByte(true);
-			packet.PutUInt(0xFFFF8080);
-			packet.PutInt(0);
-			packet.PutByte(0);
 
-			ChannelServer.Instance.World.Broadcast(packet);
+			foreach (var msg in string.Format(format, args).Chunkify(100)) // Mabi displays up to 100 chars
+			{
+				packet.PutByte(0);
+				packet.PutString("<{0}>", from);
+				packet.PutString(msg);
+				packet.PutByte(true);
+				packet.PutUInt(0xFFFF8080);
+				packet.PutInt(0);
+				packet.PutByte(0);
+
+				ChannelServer.Instance.World.Broadcast(packet);
+
+				packet.Clear(packet.Op, packet.Id);
+			}
 		}
 
 		/// <summary>
@@ -73,15 +79,21 @@ namespace Aura.Channel.Network.Sending
 		private static void SystemMessage(Creature creature, string from, string format, params object[] args)
 		{
 			var packet = new Packet(Op.Chat, creature.EntityId);
-			packet.PutByte(0);
-			packet.PutString(from);
-			packet.PutString(format, args);
-			packet.PutByte(true);
-			packet.PutUInt(0xFFFF8080);
-			packet.PutInt(0);
-			packet.PutByte(0);
 
-			creature.Client.Send(packet);
+			foreach (var msg in string.Format(format, args).Chunkify(100)) // Mabi displays up to 100 chars
+			{
+				packet.PutByte(0);
+				packet.PutString(from);
+				packet.PutString(msg);
+				packet.PutByte(true);
+				packet.PutUInt(0xFFFF8080);
+				packet.PutInt(0);
+				packet.PutByte(0);
+
+				creature.Client.Send(packet);
+
+				packet.Clear(packet.Op, packet.Id);
+			}
 		}
 
 		/// <summary>

--- a/src/Shared/Util/Extensions.cs
+++ b/src/Shared/Util/Extensions.cs
@@ -110,6 +110,7 @@ namespace Aura.Shared.Util
 		/// If a chunk would break in a word, the function backtracks to
 		/// the previous splitter char, if there is one.
 		/// 
+		/// Splitters are defined by the localization files. In English:
 		/// Splitter chars are hyphens and spaces. Spaces are stripped from the
 		/// end of chunks while hyphens are not.
 		/// </summary>
@@ -117,7 +118,7 @@ namespace Aura.Shared.Util
 		/// <param name="maxChunkLength"></param>
 		public static IEnumerable<string> Chunkify(this string str, int maxChunkLength)
 		{
-			return str.Chunkify(maxChunkLength, " ".ToCharArray(), "-".ToCharArray());
+			return str.Chunkify(maxChunkLength, Localization.Get(" ").ToCharArray(), Localization.Get("-").ToCharArray());
 		}
 
 		/// <summary>

--- a/src/Shared/Util/Extensions.cs
+++ b/src/Shared/Util/Extensions.cs
@@ -4,6 +4,8 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
+using System.Text;
 
 namespace Aura.Shared.Util
 {
@@ -99,6 +101,74 @@ namespace Aura.Shared.Util
 		public static string ToInvariant(this double f, string format = "g")
 		{
 			return f.ToString(format, CultureInfo.InvariantCulture);
+		}
+
+		/// <summary>
+		/// Breaks the specified string into chunks no longer than the
+		/// given maximum length. This can be used for word wrapping purposes.
+		/// 
+		/// If a chunk would break in a word, the function backtracks to
+		/// the previous splitter char, if there is one.
+		/// 
+		/// Splitter chars are hyphens and spaces. Spaces are stripped from the
+		/// end of chunks while hyphens are not.
+		/// </summary>
+		/// <param name="str"></param>
+		/// <param name="maxChunkLength"></param>
+		public static IEnumerable<string> Chunkify(this string str, int maxChunkLength)
+		{
+			return str.Chunkify(maxChunkLength, " ".ToCharArray(), "-".ToCharArray());
+		}
+
+		/// <summary>
+		/// Breaks the specified string into chunks no longer than the
+		/// given maximum length. This can be used for word wrapping purposes.
+		/// 
+		/// If a chunk would break in a word, the function backtracks to
+		/// the previous splitter char, if there is one.
+		/// 
+		/// Splitters in removedSplitters are stripped from the ends of chunks,
+		/// while splitters in kepSplitters are not.
+		/// </summary>
+		/// <param name="str"></param>
+		/// <param name="maxChunkLength"></param>
+		/// <param name="removedSplitters"></param>
+		/// <param name="keptSplitters"></param>
+		/// <returns></returns>
+		public static IEnumerable<string> Chunkify(this string str, int maxChunkLength, char[] removedSplitters, char[] keptSplitters)
+		{
+			var splitters = removedSplitters.Concat(keptSplitters).ToArray();
+
+			var startIndex = 0;
+
+			while (startIndex < str.Length)
+			{
+				// Calculate the maximum length of this chunk.
+				var maxIndex = Math.Min(startIndex + maxChunkLength, str.Length) - 1;
+
+				// Try to make a chunk this big.
+				var endIndex = maxIndex;
+
+				if (!splitters.Contains(str[endIndex]) && (endIndex != str.Length - 1 && !splitters.Contains(str[endIndex + 1])))
+				{
+					// If the last char in our chunk is part of a word,
+					// Try to find the start of the word
+					endIndex = str.LastIndexOfAny(splitters, maxIndex);
+
+					if (endIndex < startIndex) // We didn't find one in bounds
+						endIndex = maxIndex; // So we have to return to splitting the word
+				}
+
+				// Make our chunk. We'll leave splitters at the start, if they exist.
+				var chunk = str.Substring(startIndex, endIndex - startIndex + 1).TrimEnd(removedSplitters);
+
+				// If we get a chunk that's all removed splitters, don't output it
+				if (chunk.Length != 0)
+					yield return chunk;
+
+				// Start on the next chunk
+				startIndex = endIndex + 1;
+			}
 		}
 	}
 }


### PR DESCRIPTION
Mabi can only show 100 chars per message. System messages, like command
help (esp the output of go) can exceed 100 chars and are just cut off.

This commit adds a word-wrapping algorithm and changes system messages so
the message is first wrapped by 100 chars (Mabi's limit) and then sent in
multiple messages.

Before:
![](http://puu.sh/ldyhY/1c7e7e59e6.jpg)

After:
![](http://puu.sh/ldykP/55ddc58701.jpg)