### PR TITLE
Updated script loading messages.

### DIFF
--- a/src/Shared/Scripting/ScriptManager.cs
+++ b/src/Shared/Scripting/ScriptManager.cs
@@ -89,13 +89,15 @@ namespace Aura.Shared.Scripting
 			// Load scripts
 			var loaded = this.LoadScripts(toLoad);
 
+			Log.Info("  loaded {0} scripts ({1} failed).", loaded, toLoad.Count - loaded);
+
 			// Init scripts
+			Log.Info("Initializing scripts...");
 			this.InitializeScripts();
+			Log.Info("  script initialization complete");
 
 			//if (toLoad.Count > 0)
 			//	Log.WriteLine();
-
-			Log.Info("  done loading {0} scripts (of {1}).", loaded, toLoad.Count);
 		}
 
 		/// <summary>


### PR DESCRIPTION
The loading message is now a little clearer regarding what actually happened. Initialization gets its own section. This is twofold. First, script init errors won't woverwrite the progress bar, and second, since
loading and init are two separate concepts, this will help localize any error messages that show up.

Both messages use the slightly-smoother "past-tense-verb" form instead of the "done verb-infinitive". This is a minor point, but it's a little friendlier in terms of English.