### PR TITLE
Improves ChannelStatus reporting

### DIFF
--- a/src/ChannelServer/ChannelServer.cs
+++ b/src/ChannelServer/ChannelServer.cs
@@ -33,7 +33,15 @@ namespace Aura.Channel
 		/// </summary>
 		private const int LoginTryTime = 10 * 1000;
 
-		private bool _running = false;
+		/// <summary>
+		/// Used to determine if the server is running
+		/// </summary>
+		public bool IsRunning { get; private set; }
+
+		/// <summary>
+		/// Gets or sets whether the server is in maintenance. 
+		/// </summary>
+		public bool IsInMaintenance { get; set; }
 
 		/// <summary>
 		/// Instance of the actual server component.
@@ -97,7 +105,7 @@ namespace Aura.Channel
 		/// </summary>
 		public void Run()
 		{
-			if (_running)
+			if (this.IsRunning)
 				throw new Exception("Server is already running.");
 
 			CliUtil.WriteHeader("Channel Server", ConsoleColor.DarkGreen);
@@ -141,7 +149,7 @@ namespace Aura.Channel
 			this.StartStatusUpdateTimer();
 
 			CliUtil.RunningTitle();
-			_running = true;
+			this.IsRunning = true;
 
 			// Commands
 			this.ConsoleCommands.Wait();
@@ -208,6 +216,16 @@ namespace Aura.Channel
 
 			Log.Info("Connection to login server at '{0}' established.", this.LoginServer.Address);
 			Log.WriteLine();
+		}
+
+		/// <summary>
+		/// Sets whether the server is in maintenance with notification to the login server
+		/// </summary>
+		/// <param name="isInMaintenance"></param>
+		public void SetMaintenance(bool isInMaintenance)
+		{
+			this.IsInMaintenance = isInMaintenance;
+			Send.Internal_ChannelStatus();
 		}
 
 		private void OnClientDisconnected(ChannelClient client)

--- a/src/ChannelServer/ChannelServer.cs
+++ b/src/ChannelServer/ChannelServer.cs
@@ -20,7 +20,6 @@ using Aura.Shared.Util;
 using Aura.Shared.Util.Configuration;
 using System;
 using System.Net.Sockets;
-using System.Runtime.CompilerServices;
 using System.Threading;
 
 namespace Aura.Channel

--- a/src/ChannelServer/Network/Sending/Send.Internal.cs
+++ b/src/ChannelServer/Network/Sending/Send.Internal.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Aura development team - Licensed under GNU GPL
 // For more information, see license file in the main folder
 
-using System;
 using Aura.Mabi.Network;
 using Aura.Shared.Network;
 using Aura.Shared.Util;
@@ -23,6 +22,14 @@ namespace Aura.Channel.Network.Sending
 
 		/// <summary>
 		/// Sends Internal.ChannelStatus to login server.
+		/// </summary>
+		public static void Internal_ChannelStatus()
+		{
+			Internal_ChannelStatus(ChannelServer.Instance.CalculateChannelState());
+		}
+
+		/// <summary>
+		/// Sends Internal.ChannelStatus to login server with specified ChannelState.
 		/// </summary>
 		public static void Internal_ChannelStatus(ChannelState state)
 		{

--- a/src/ChannelServer/Network/Sending/Send.Internal.cs
+++ b/src/ChannelServer/Network/Sending/Send.Internal.cs
@@ -36,52 +36,9 @@ namespace Aura.Channel.Network.Sending
 			packet.PutInt(ChannelServer.Instance.Conf.Channel.ChannelPort);
 			packet.PutInt(cur);
 			packet.PutInt(max);
-			packet.PutInt((int) GetServerState(cur, max, ChannelServer.Instance.IsRunning, 
-				ChannelServer.Instance.IsInMaintenance));
+			packet.PutInt((int) ChannelServer.Instance.CalculateChannelState());
 
 			ChannelServer.Instance.LoginServer.Send(packet);
-		}
-
-		/// <summary>
-		/// Calculates the state of the channel.
-		/// </summary>
-		/// <remarks>
-		/// When calculating the <see cref="ChannelState"/> we take into account
-		/// whether the server is running as well as if it is in Maintenance.
-		/// </remarks>
-		/// <param name="current"></param>
-		/// <param name="max"></param>
-		/// <param name="isRunning"></param>
-		/// <param name="isInMaintenance"></param>
-		/// <returns></returns>
-		private static ChannelState GetServerState(int current, int max, bool isRunning, bool isInMaintenance)
-		{
-			if (isInMaintenance)
-				// In case we do support the booting channel state
-				return isRunning ? ChannelState.Maintenance : ChannelState.Booting;
-
-			double stress;
-
-			try
-			{
-				stress = (current / max) * 100;
-			}
-			catch (DivideByZeroException ex)
-			{
-				Log.Exception(ex, "Max user count was zero, falling back to Normal.");
-				
-				// Fallback value
-				return ChannelState.Normal;
-			}
-
-			if (stress >= 40 && stress <= 70)
-				return ChannelState.Busy;
-			if (stress > 70 && stress <= 95)
-				return ChannelState.Full;
-			if (stress > 95)
-				return ChannelState.Bursting;
-
-			return ChannelState.Normal;
 		}
 
 		/// <summary>


### PR DESCRIPTION
* ChannelStatus is calculated based off the comments for each
ChannelStatus enum.

* IsInMaintenance can be used to set the server to Maintenance easily since it
is something one might do in a script, the other states should happen
automatically.

// Questions

Should we hold the ChannelStatus as a property and allow changes that was with automatic updates on change? I think that would break the design of the PR but maybe it's better?