### PR TITLE
Events for early login phases.

### DIFF
--- a/src/ChannelServer/Network/Handlers/LogInOut.cs
+++ b/src/ChannelServer/Network/Handlers/LogInOut.cs
@@ -63,7 +63,7 @@ namespace Aura.Channel.Network.Handlers
 			}
 
 			// Check character
-			var character = account.GetCharacterOrPetSafe(characterId);
+			var character = account.GetCharacterOrPetSafe(characterId) as Creature;
 
 			// Free premium
 			account.PremiumServices.EvaluateFreeServices(ChannelServer.Instance.Conf.Premium);
@@ -74,6 +74,16 @@ namespace Aura.Channel.Network.Handlers
 			character.Client = client;
 
 			client.State = ClientState.LoggedIn;
+
+			// Per-character specific initialization
+			NPC npcchar = character as NPC;
+			if (npcchar != null && npcchar.OnNPCLoggedIn != null)
+			{
+				// Seems like officials send here packet-per-packet adding equipment,
+				// skills and probably other initialization info for RP NPCs
+				// Long story short, a lot of StatUpdate, SkillRankUp, ItemNew, etc. packets
+				npcchar.OnNPCLoggedIn();
+			}
 
 			Send.ChannelLoginR(client, character.EntityId);
 
@@ -214,6 +224,9 @@ namespace Aura.Channel.Network.Handlers
 			// Infamous 5209, aka char info
 			Send.ChannelCharacterInfoRequestR(client, creature);
 
+			// Send any necessary "feature enabled" packets, grant extra items, update quests, etc.
+			ChannelServer.Instance.Events.OnCreatureConnecting(creature);
+
 			// Special treatment for pets
 			if (creature.Master != null)
 			{
@@ -284,8 +297,19 @@ namespace Aura.Channel.Network.Handlers
 			// Update Pon
 			Send.PointsUpdate(creature, creature.Points);
 
+			// Send UrlUpdate packets?
+			// - UrlUpdateChronicle
+			// - UrlUpdateAdvertise
+			// - UrlUpdateGuestbook
+			// - UrlUpdatePvp
+			// - UrlUpdateDungeonBoard
+
 			// Update dead menu, in case creature is dead
 			creature.DeadMenu.Update();
+
+			// Any extra ChannelInfo initialization from scripts
+			// Actual first update of features
+			ChannelServer.Instance.Events.OnCreatureConnected(creature);
 		}
 
 		/// <summary>

--- a/src/ChannelServer/World/Entities/NPC.cs
+++ b/src/ChannelServer/World/Entities/NPC.cs
@@ -53,6 +53,11 @@ namespace Aura.Channel.World.Entities
 		public GiftWeightInfo GiftWeights { get; set; }
 
 		/// <summary>
+		/// For initializing RP NPCs on login
+		/// </summary>
+		public Action OnNPCLoggedIn { get; protected set; }
+
+		/// <summary>
 		/// Location the NPC was spawned at.
 		/// </summary>
 		public Location SpawnLocation { get; set; }

--- a/src/ChannelServer/World/EventManager.cs
+++ b/src/ChannelServer/World/EventManager.cs
@@ -71,6 +71,20 @@ namespace Aura.Channel.World
 		// ------------------------------------------------------------------
 
 		/// <summary>
+		// For sending any packets that need to be sent
+		// to each and every character on login
+		// Examples: Enabling/disabling client features
+		/// </summary>
+		public event Action<Creature> CreatureConnecting;
+		public void OnCreatureConnecting(Creature creature) { CreatureConnecting.Raise(creature); }
+
+		// For sending packets that need to be sent
+		// to specific characters on login
+		// Examples: Initial values for enabled features
+		public event Action<Creature> CreatureConnected;
+		public void OnCreatureConnected(Creature creature) { CreatureConnected.Raise(creature); }
+
+		/// <summary>
 		/// Raised a few seconds after player logged in.
 		/// </summary>
 		public event Action<Creature> PlayerLoggedIn;


### PR DESCRIPTION
The Connecting events will be needed at some point anyway.
Used "Creature" instead of "Player", because both primary and secondary characters receive that info.

That `NPC npcchar = character as NPC;` will make sense a bit later. Planning to use it to update any necessary info about secondary characters that are connecting.