### PR TITLE
Updated Deian, Dilys, and Duncan

### DIFF
--- a/system/scripts/npcs/tir/deian.cs
+++ b/system/scripts/npcs/tir/deian.cs
@@ -14,6 +14,7 @@ public class DeianScript : NpcScript
 		SetFace(skinColor: 23, eyeType: 19, eyeColor: 0, mouthType: 0);
 		SetStand("human/male/anim/male_natural_stand_npc_deian");
 		SetLocation(1, 27953, 42287, 158);
+		SetGiftWeights(beauty: 0, individuality: 1, luxury: -1, toughness: 0, utility: 2, rarity: 1, meaning: -1, adult: -1, maniac: 2, anime: 2, sexy: 2);
 
 		EquipItem(Pocket.Face, 4900, 0x00FFDC53, 0x00FFB682, 0x00A8DDD3);
 		EquipItem(Pocket.Hair, 4156, 0x00E7CB60, 0x00E7CB60, 0x00E7CB60);
@@ -38,12 +39,7 @@ public class DeianScript : NpcScript
 	{
 		SetBgm("NPC_Deian.mp3");
 
-		await Intro(
-			"An adolescent boy carrying a shepherd's staff watches over a flock of sheep.",
-			"Now and then, he hollers at some sheep that've wandered too far, and his voice cracks every time.",
-			"His skin is tanned and his muscles are strong from his daily work.",
-			"Though he's young, he peers at you with so much confidence it almost seems like arrogance."
-		);
+		await Intro(L("An adolescent boy carrying a shepherd's staff watches over a flock of sheep.<br/>Now and then, he hollers at some sheep that've wandered too far, and his voice cracks every time.<br/>His skin is tanned and his muscles are strong from his daily work.<br/>Though he's young, he peers at you with so much confidence it almost seems like arrogance."));
 
 		Msg("What can I do for you?", Button("Start a Conversation", "@talk"), Button("Shop", "@shop"), Button("Modify Item", "@upgrade"));
 
@@ -71,7 +67,11 @@ public class DeianScript : NpcScript
 					}
 				}
 
-				if (Title == 11002)
+				if (Title == 11001)
+				{
+					Msg("Hey! <username/>, that's my job you just did! What am I supposed to do now?<br/>Man! There must be something more heroic that I could do as a warrior...");
+				}
+				else if (Title == 11002)
 				{
 					Msg("Eh? <username/>...<br/>You've become the Guardian of Erinn?<br/>So fast!<br/>I'm still trying to become a Warrior!");
 					Msg("Good for you.<br/>Just make sure you leave me some work to do for when I become a Warrior.<br/>Wow, must've been tough.");
@@ -106,7 +106,7 @@ public class DeianScript : NpcScript
 				break;
 		}
 
-		End();
+		End("(You ended your conversation with Deian.)");
 	}
 
 	private void Greet()
@@ -140,15 +140,15 @@ public class DeianScript : NpcScript
 		switch (keyword)
 		{
 			case "personal_info":
-				Msg("Yeah, yeah. I'm a mere shepherd...for now.<br/>But I will soon be a mighty warrior!<br/>");
-				ModifyRelation(Random(2), 0, Random(2));
+				Msg(FavorExpression(), "Yeah, yeah. I'm a mere shepherd...for now.<br/>But I will soon be a mighty warrior!<br/>");
+				ModifyRelation(Random(2), 0, Random(3));
 				break;
 
 			case "rumor":
 				GiveKeyword("pool");
-				Msg("Some people should have been born as fish.<br/>They can't pass water without diving right in.<br/>I wish they'd stop.");
+				Msg(FavorExpression(), "Some people should have been born as fish.<br/>They can't pass water without diving right in.<br/>I wish they'd stop.");
 				Msg("Not long ago, someone jumped into the reservoir<br/>and made a huge mess.<br/>Guess who got stuck cleaning it up?<br/>Sooo not my job.");
-				ModifyRelation(Random(2), 0, Random(2));
+				ModifyRelation(Random(2), 0, Random(3));
 
 				/* Message from Field Boss Spawns
 				Msg("<face name='normal'/>A monster will show up in Eastern Prairie of the Meadow at 3Days later Dawn!<br/>Gigantic White Wolf will show up!<br/>Hey, I said I'm not lying!");
@@ -331,12 +331,31 @@ public class DeianScript : NpcScript
 				Msg("You know it's on your Minimap...<br/>Asking all these foolish questions...<br/>What's your problem?");
 				break;
 
+			case "bow":
+				GiveKeyword("shop_smith");
+				Msg("You can find a lot of bows at the Blacksmith's Shop.<br/>There's one nearby.<br/>If Ferghus is drunk, it might be possible to sneak one out.");
+				Msg("I'm just kidding! You weren't really thinking about doing that...were you?");
+				break;
+
 			case "lute":
 				Msg("Oh... I want a red lute.<br/>Why don't you buy me one when you get rich, yea?");
 				break;
 
 			case "complicity":
 				Msg("Welcome to the real world...");
+				break;
+
+			case "tir_na_nog":
+				Msg("Haha.... Tir Na Nog?<br/>Surely you don't really believe that place exists?<br/>Adults just make up stories to control their children.<br/>Don't take it so seriously.");
+				break;
+
+			case "mabinogi":
+				Msg("You think I'm a dumb shepherd, huh?<br/>Don't look down on me, bro. I know what you're talking about!");
+				Msg("It's uh...<br/>It's a song those bards sing all the time! Right? Right?<br/>Psh. I know more than you think!");
+				break;
+
+			case "musicsheet":
+				Msg("Music Score? I heard you need it to play music.<br/>I am interested in instruments but not so much in Music Scores.");
 				break;
 
 			default:
@@ -350,7 +369,7 @@ public class DeianScript : NpcScript
 					"Sometimes, I'm just not in the mood to answer questions.",
 					"Don't be ridiculous. It's not that I don't know, I just don't want to tell you."
 				);
-				ModifyRelation(0, 0, Random(2));
+				ModifyRelation(0, 0, Random(3));
 				break;
 		}
 	}
@@ -360,7 +379,7 @@ public class DeianShop : NpcShopScript
 {
 	public override void Setup()
 	{
-		AddQuest("Party Quest", 100007, 5); // [PQ] Hunt Gray Wolves (10)
+		AddQuest("Party Quest", 100007, 5);  // [PQ] Hunt Gray Wolves (10)
 		AddQuest("Party Quest", 100008, 20); // [PQ] Hunt Gray Wolves (30)
 		AddQuest("Party Quest", 100009, 15); // [PQ] Hunt Black Wolves (10)
 		AddQuest("Party Quest", 100010, 50); // [PQ] Hunt Black Wolves (30)

--- a/system/scripts/npcs/tir/dilys.cs
+++ b/system/scripts/npcs/tir/dilys.cs
@@ -14,6 +14,7 @@ public class DilysScript : NpcScript
 		SetFace(skinColor: 17, eyeType: 3, eyeColor: 27, mouthType: 48);
 		SetStand("human/female/anim/female_natural_stand_npc_Dilys_retake");
 		SetLocation(6, 1107, 1050, 195);
+		SetGiftWeights(beauty: 0, individuality: 2, luxury: 1, toughness: 0, utility: 0, rarity: 0, meaning: 1, adult: 2, maniac: 0, anime: -1, sexy: -1);
 
 		EquipItem(Pocket.Face, 3908, 0x0058B49E, 0x00365C72, 0x00D6EEF5);
 		EquipItem(Pocket.Hair, 3141, 0x00633C31, 0x00633C31, 0x00633C31);
@@ -31,11 +32,7 @@ public class DilysScript : NpcScript
 
 	protected override async Task Talk()
 	{
-		await Intro(
-			"A tall, slim lady tinkers with various ointments, herbs, and bandages.",
-			"She looks wise beyond her years, but it might just be the healer's dress",
-			"and neatly combed hair."
-		);
+		await Intro(L("A tall, slim lady tinkers with various ointments, herbs, and bandages.<br/>She looks wise beyond her years, but it might just be the healer's dress<br/>and neatly combed hair."));
 
 		Msg("Welcome to the Healer's House.", Button("Start a Conversation", "@talk"), Button("Shop", "@shop"), Button("Get Treatment", "@healerscare"), Button("Heal Pet", "@petheal"));
 
@@ -74,7 +71,9 @@ public class DilysScript : NpcScript
 					}
 				}
 
-				if (Title == 11002)
+				if (Title == 11001)
+					Msg("...<username/>, Who Saved the Goddess?<br/>...<br/>Ugh, spare me.<br/>Trefor suffices as the town fool and we only need one.");
+				else if (Title == 11002)
 					Msg("Sigh...<br/>As if Trefore weren't enough...<br/>Do we really need more dummies in this town?");
 
 				await Conversation();
@@ -183,15 +182,15 @@ public class DilysScript : NpcScript
 		{
 			case "personal_info":
 				GiveKeyword("shop_healing");
-				Msg("A healer's job is to treat sick people.<br/>Don't hesitate to come to me if you ever feel sick.");
-				ModifyRelation(Random(2), 0, Random(2));
+				Msg(FavorExpression(), "A healer's job is to treat sick people.<br/>Don't hesitate to come to me if you ever feel sick.");
+				ModifyRelation(Random(2), 0, Random(3));
 				break;
 
 			case "rumor":
 				GiveKeyword("graveyard");
-				Msg("It was hard for you to get here, wasn't it? I bet if I were a little closer to the Square<br/>you would've come earlier. Hehe...<br/>Truthfully, it is kind of scary being next to the graveyard.");
+				Msg(FavorExpression(), "It was hard for you to get here, wasn't it? I bet if I were a little closer to the Square<br/>you would've come earlier. Hehe...<br/>Truthfully, it is kind of scary being next to the graveyard.");
 				Msg("At first I thought about opening the Healer's House near the Square<br/>but Duncan advised me that this place would be better for business.<br/>Actually, I haven't had many patients.<br/>Only people who come to hunt spiders and...Trefor, who stores his goods here...");
-				ModifyRelation(Random(2), 0, Random(2));
+				ModifyRelation(Random(2), 0, Random(3));
 
 				/* Message from Field Boss Spawns
 				Msg("<face name='normal'/>Head to Eastern Prairie of the Meadow right away!<br/>Trefor made a fuss because of Gigantic White Wolf's attack.");
@@ -316,7 +315,7 @@ public class DilysScript : NpcScript
 				break;
 
 			case "shop_armory":
-				GiveKeyword("shop_smith");
+				GiveKeyword("shop_inn");
 				Msg("Hmm... We don't have a shop that sells weapons here...<br/>But you could go and talk to Ferghus.<br/>His Blacksmith's Shop is past the Inn, just across the bridge.");
 				break;
 
@@ -339,6 +338,31 @@ public class DilysScript : NpcScript
 				Msg("The graveyard? Just go up the hill. <be/>But, really? Asking about the graveyard at the Healer's House?<br/>Haha, you're quite strange...");
 				break;
 
+			case "bow":
+				Msg("A bow is a dangerous weapon.<br/>You need to be very careful with them.<br/>Most of the patients who come here<br/>were wounded by weapons like that.");
+				break;
+
+			case "lute":
+				Msg("There are many instruments besides lutes.<br/>But that's the only one you'll find in this town.<br/>I'm sure that when you go to another city<br/>your mouth will hang open, staring at all the different choices... Hehe...");
+				break;
+
+			case "complicity":
+				Msg("Huh? Did something happen?<br/>Why do you bring that up?");
+				break;
+
+			case "tir_na_nog":
+				Msg("Tir Na Nog?<br/>It's the legendary fantasy world.<br/>No one has ever seen the place...<br/>I sometimes wonder how that story originated.");
+				break;
+
+			case "mabinogi":
+				Msg("If you want to know more about Mabinogi,<br/>you will get more answers from the elders in this town than from me.<br/>Someone like Chief Duncan or Priest Meven...");
+				break;
+
+			case "musicsheet":
+				GiveKeyword("shop_misc");
+				Msg("Music Score? The General Shop should sell them....<br/>Haven't you been there, yet?");
+				break;
+
 			default:
 				RndMsg(
 					"Eh?",
@@ -347,7 +371,7 @@ public class DilysScript : NpcScript
 					"Did you ask others about this as well?",
 					"Did they say they didn't know about it either?<br/>Well..."
 				);
-				ModifyRelation(0, 0, Random(2));
+				ModifyRelation(0, 0, Random(3));
 				break;
 		}
 	}

--- a/system/scripts/npcs/tir/duncan.cs
+++ b/system/scripts/npcs/tir/duncan.cs
@@ -4,7 +4,7 @@
 // Chief of Tir Chonaill (outside Chief's House)
 //---------------------------------------------------------------------------
 
-public class DuncanBaseScript : NpcScript
+public class DuncanScript : NpcScript
 {
 	public override void Load()
 	{
@@ -36,11 +36,7 @@ public class DuncanBaseScript : NpcScript
 	{
 		SetBgm("NPC_Duncan.mp3");
 
-		await Intro(
-			"An elderly man gazes softly at the world around him with a calm air of confidence.",
-			"Although his face appears weather-beaten, and his hair and beard are gray, his large beaming eyes make him look youthful somehow.",
-			"As he speaks, his voice resonates with a kind of gentle authority."
-		);
+		await Intro(L("An elderly man gazes softly at the world around him with a calm air of confidence.<br/>Although his face appears weather-beaten, and his hair and beard are gray, his large beaming eyes make him look youthful somehow.<br/>As he speaks, his voice resonates with a kind of gentle authority."));
 
 		Msg("Please let me know if you need anything.", Button("Start Conversation", "@talk"), Button("Shop", "@shop"), Button("Retrive Lost Items", "@lostandfound"));
 
@@ -88,7 +84,11 @@ public class DuncanBaseScript : NpcScript
 					}
 				}
 
-				if (Title == 11002)
+				if (Title == 11001)
+				{
+					Msg("You rescued the Goddess? And defeated Glas Ghaibhleann?<br/>Well done! A great accomplishment.<br/>However, most people won't understand the gravity of what you have just done.<br/>But don't be disappointed. Erinn shall prosper for a long time, thanks to you.<br/>Accept my deepest gratitude as Chief of this town.");
+				}
+				else if (Title == 11002)
 				{
 					Msg("Oh. <username/>! You finally did it...<br/>I can't believe you became the Knight of Light and saved Erinn...<br/>Nao would be so proud.");
 					Msg("I'm starting to understand Goddess Morrighan and Nao's will<br/>for sending people like you to this world.");
@@ -143,68 +143,101 @@ public class DuncanBaseScript : NpcScript
 		switch (keyword)
 		{
 			case "personal_info":
-				if (Favor > 40)
+				if (Memory >= 15 && Favor >= 30 && Stress <= 5)
 				{
-					Msg("See that bird on the tree over there? When I was young, he used to help me on the battlefield.<br/>Now he's as old as I am and sleeps all the time.<br/>Perhaps he has closed his heart in disappointment at my present appearance, so old and changed...");
+					Msg(FavorExpression(), "My name, <npcname/>, is a warrior name.<br/>My father gave it to me hoping that I would become a great warrior leader.");
+					ModifyRelation(Random(2), 0, Random(2));
+				}
+				else if (Favor >= 10 && Stress <= 10)
+				{
+					Msg(FavorExpression(), "See that bird on the tree over there? When I was young, he used to help me on the battlefield.<br/>Now he's as old as I am and sleeps all the time.<br/>Perhaps he has closed his heart in disappointment at my present appearance, so old and changed...");
+					ModifyRelation(Random(2), Random(2), Random(2));
 				}
 				else
 				{
-					GiveKeyword("shop_headman");
-					Msg("Once again, welcome to Tir Chonaill.");
-				}
-
-				ModifyRelation(Random(2), 0, Random(2));
-				break;
-
-			case "rumor":
-				if (Favor > 40)
-					Msg("The weather here changes unpredictably because Tir Chonaill is located high up in the mountains.<br/>There are instances where bridges collapse and roads are destroyed after a heavy rainfall,<br/>and people lose all contact with the outside world.<br/>Despite that, I think you've done quite well here.");
-				else
-					Msg("I heard a rumor that this is just a copy of the world of Erin. Trippy, huh?");
-
-
-				ModifyRelation(Random(2), 0, Random(2));
-
-				/* More data - unsure where it goes
-
-				// This message came up first
-				Msg("Talk to the good people in Tir Chonaill as much as you can, and pay close attention to what they say.<br/>Once you become friends with them, they will help you in many ways.<br/>Why don't you start off by visiting the buildings around the Square?");
-
-				// Then this message always came up afterwards, except on field boss info
-				Msg("<face name='normal'/>Have you heard of field bosses?<br/>They are very powerful monsters that appear randomly in places outside dungeons, like open fields.<br/>Field bosses are either a Fomor or an animal affected by the forces of evil and transformed into a huge, savage creature.");
-				Msg("Field bosses usually show up with several monsters with them,<br/>so they pose a big threat to travelers.<br/>If you want to face a field boss, the people in town will tell you about them<br/>if you ask about nearby rumors a few times.");
-				Msg("<title name='NONE'/>(The conversation drew a lot of interest.)"); 
-
-				// Message from Field Boss Spawns
-				Msg("<face name='normal'/>I have something to tell you.<br/>Can you feel the evil presence of Gigantic White Wolf spreading around Southern Plains of Tir Chonaill?<br/>I think something bad will happen in around 3Days late Afternoon...");
-				Msg("<title name='NONE'/>(That was a great conversation!)"); */
-				break;
-
-			case "about_skill":
-				// Duncan used to check for race, but stopped some time after G13, so a feature check should go here
-				if (HasSkill(SkillId.RangedAttack) && !HasSkill(SkillId.MagnumShot))
-				{
-					GiveKeyword("skill_magnum_shot");
-					Msg("You seem much more comfortable conversing with people using the 'Skills' keyword now.<br/>Wait. You can shoot an arrow? Congratulations!<br/>You've only been here for a short time, yet you pick up things so fast.");
-					Msg("Now, have you heard about Magnum Shot?<br/>You see, a bow is great for attacking enemies from a distance,<br/>yet it's frustrating when you miss a target.<br/>Plus, the damage from a bow isn't as strong as a melee attack.");
-					Msg("Since you were so diligent, I will teach you<br/>Magnum Shot, which I learned from Ranald.");
-					Msg("The Magnum Shot skill helps you to shoot a powerful arrow<br/>with the power you have concentrated in your bow.<br/>Go on and work on your training...");
-					// Duncan started giving the skill some time after G13, so a feature check should go here
-					// On official, he adds the skill as rNovice, then adds on 100 skill training
-					GiveSkill(SkillId.MagnumShot, SkillRank.RF);
-					break;
-				}
-				else
-				{
-					if (HasSkill(SkillId.Rest))
+					if (Title == 33)
 					{
-						Msg("You know about the Combat Mastery skill?<br/>It's one of the basic skills needed to protect yourself in combat.<br/>It may look simple, but never underestimate its efficiency.<br/>Continue training the skill diligently and you will soon reap the rewards. That's a promise.");
+						Msg(FavorExpression(), "Now that I think about it, I have something to tell you...<br/>Oh, it's not serious. But you have quite the reputation around here.<br/>Your diligence and hard work is well known to everyone in town.<br/>People say you're good-hearted and a decent human being.<br/>I trust you too, so keep up the good work.");
 					}
 					else
 					{
-						Msg("Whatever you do, skills will be an essential part of your life.<br/>There are various ways to learn skills,<br/>but the best way is to talk to people in town using the 'Skills' keyword.");
-						Msg("First, go and meet the people of Tir Chonaill, and use this keyword to ask them questions.<br/>They will teach you everything about skills they know,<br/>but that doesn't mean they will tell you everything YOU want to know.<br/>The town residents aren't experts.");
-						Msg("So my advice is to not get frustrated.<br/>Even if you don't learn a skill right away, if you follow their guidance,<br/>you'll eventually find someone who can teach you the skill.<br/>If I were you, I would listen carefully to what people say.");
+						GiveKeyword("shop_headman");
+						Msg(FavorExpression(), "Once again, welcome to Tir Chonaill.");
+					}
+					ModifyRelation(Random(2), 0, Random(3));
+				}
+				break;
+
+			case "rumor":
+				if (Memory >= 15 && Favor >= 30 && Stress <= 5)
+				{
+					GiveKeyword("graveyard");
+					Msg(FavorExpression(), "In the graveyard lay those who sacrificed their lives<br/>to keep Tir Chonaill safe from monsters and evil creatures...");
+					ModifyRelation(Random(2), 0, Random(2));
+				}
+				else if (Favor >= 10 && Stress <= 10)
+				{
+					Msg(FavorExpression(), "The weather here changes unpredictably because Tir Chonaill is located high up in the mountains.<br/>There are instances where bridges collapse and roads are destroyed after a heavy rainfall,<br/>and people lose all contact with the outside world.<br/>Despite that, I think you've done quite well here.");
+					ModifyRelation(Random(2), Random(2), Random(3));
+				}
+				else
+				{
+					if (!HasKeyword("square"))
+					{
+						GiveKeyword("square");
+						Msg(FavorExpression(), "Talk to the good people in Tir Chonaill as much as you can, and pay close attention to what they say.<br/>Once you become friends with them, they will help you in many ways.<br/>Why don't you start off by visiting the buildings around the Square?");
+					}
+					else
+					{
+						Msg(FavorExpression(), "Have you heard of field bosses?<br/>They are very powerful monsters that appear randomly in places outside dungeons, like open fields.<br/>Field bosses are either a Fomor or an animal affected by the forces of evil and transformed into a huge, savage creature.");
+						Msg("Field bosses usually show up with several monsters with them,<br/>so they pose a big threat to travelers.<br/>If you want to face a field boss, the people in town will tell you about them<br/>if you ask about nearby rumors a few times.");
+					}
+					ModifyRelation(Random(2), 0, Random(3));
+				}
+
+				/* Not sure where this goes
+				Msg("I heard a rumor that this is just a copy of the world of Erin. Trippy, huh?");
+
+				// Message from Field Boss Spawns
+				Msg("<face name='normal'/>I have something to tell you.<br/>Can you feel the evil presence of Gigantic White Wolf spreading around Southern Plains of Tir Chonaill?<br/>I think something bad will happen in around 3Days late Afternoon...");
+				Msg("<title name='NONE'/>(That was a great conversation!)");
+				
+				// Message during Field Boss
+				Msg("<face name='normal'/>Why are you here?<br/>I saw people running to Eastern Prairie of the Meadow.<br/>They were running to save their friends in peril after Gigantic White Wolf showed up."); */
+				break;
+
+			case "about_skill":
+				// Duncan used to check for only humans, but stopped some time after G13, so a feature check should go here
+				if (Player.IsGiant)
+				{
+					Msg("Hehe. Sorry, but there's not much that I can teach you...");
+				}
+				else
+				{
+					if (HasSkill(SkillId.RangedAttack) && !HasSkill(SkillId.MagnumShot))
+					{
+						GiveKeyword("skill_magnum_shot");
+						Msg("You seem much more comfortable conversing with people using the 'Skills' keyword now.<br/>Wait. You can shoot an arrow? Congratulations!<br/>You've only been here for a short time, yet you pick up things so fast.");
+						Msg("Now, have you heard about Magnum Shot?<br/>You see, a bow is great for attacking enemies from a distance,<br/>yet it's frustrating when you miss a target.<br/>Plus, the damage from a bow isn't as strong as a melee attack.");
+						Msg("Since you were so diligent, I will teach you<br/>Magnum Shot, which I learned from Ranald.");
+						Msg("The Magnum Shot skill helps you to shoot a powerful arrow<br/>with the power you have concentrated in your bow.<br/>Go on and work on your training...");
+						// Duncan started giving the skill some time after G13, so a feature check should go here
+						// On official, he adds the skill as rNovice, then adds on 100 skill training
+						GiveSkill(SkillId.MagnumShot, SkillRank.RF);
+						break;
+					}
+					else
+					{
+						if (HasSkill(SkillId.Rest))
+						{
+							Msg("You know about the Combat Mastery skill?<br/>It's one of the basic skills needed to protect yourself in combat.<br/>It may look simple, but never underestimate its efficiency.<br/>Continue training the skill diligently and you will soon reap the rewards. That's a promise.");
+						}
+						else
+						{
+							Msg("Whatever you do, skills will be an essential part of your life.<br/>There are various ways to learn skills,<br/>but the best way is to talk to people in town using the 'Skills' keyword.");
+							Msg("First, go and meet the people of Tir Chonaill, and use this keyword to ask them questions.<br/>They will teach you everything about skills they know,<br/>but that doesn't mean they will tell you everything YOU want to know.<br/>The town residents aren't experts.");
+							Msg("So my advice is to not get frustrated.<br/>Even if you don't learn a skill right away, if you follow their guidance,<br/>you'll eventually find someone who can teach you the skill.<br/>If I were you, I would listen carefully to what people say.");
+						}
 					}
 				}
 				break;
@@ -242,7 +275,6 @@ public class DuncanBaseScript : NpcScript
 				Msg("Are you tired?<br/>The Inn is near the town entrance, so just go further down.<br/>Nora will be at the door to greet you.<br/>If you have time, go and talk to her.");
 				break;
 
-
 			case "shop_bank":
 				Msg("It's been a while since the Erskin Bank first opened its doors...<br/>It's that big building with a tiled roof below in the Square.<br/>There, you'll find Bebhinn, the teller.<br/>She knows a lot of gossip, so talk to her if you're curious.");
 				break;
@@ -252,6 +284,7 @@ public class DuncanBaseScript : NpcScript
 				break;
 
 			case "skill_range":
+				GiveKeyword("school");
 				Msg("Hmm. I could tell you some things about long-ranged attacks,<br/>but I think it's better for you to ask Ranald.<br/>Don't take it personally! I just think you should learn from an expert.");
 				Msg("Long-ranged attacks consist of attacking a monster at a distance with a bow or a rock.<br/>But you need to spend time training, as long-ranged attacks and melee attacks use different muscles.");
 				break;
@@ -368,6 +401,38 @@ public class DuncanBaseScript : NpcScript
 				Msg("You have a good hobby.<br/>Make sure to buy plenty of Bait Tins.<br/>Otherwise you might end up regretting it later.<br/>Hahaha.");
 				break;
 
+			case "bow":
+				Msg("Looking for a bow?<br/>Ah, Ranald told you to head to the Blacksmith's Shop and talk to Ferghus, right?<br/>But the look on your face tells me you were hoping Ranald would just give you one.<br/>Hahaha! Yes, as Chief of this town, I know everything that goes on.");
+				Msg("But listen to me. Don't bear a grudge against Ranald.<br/>He may not be the best at expressing himself, but he's a sensitive man who pays attention to details.<br/>He's been teaching many people about combat lately.<br/>Think about it. He can't give a bow to each and every one of his students, right?");
+				Msg("Besides, you need to learn how to obtain your own equipment.<br/>Now hurry to the Blacksmith's Shop and buy a bow.<br/>Remember to have enough Gold in your inventory to pay for it!");
+				break;
+
+			case "lute":
+				GiveKeyword("shop_misc");
+				Msg("You can find lutes and other items at Malcolm's General Shop.<br/>Why don't you go take a look?");
+				break;
+
+			case "complicity":
+				Msg("I'm not encouraging that you think of the townspeople as naive, simple folk,<br/>but I hope you are not too suspicious of them, either.");
+				break;
+
+			case "tir_na_nog":
+				Msg("Tir Na Nog... The paradise everyone in Erinn dreams of.<br/>At Tir Na Nog, there is no death, pain, or sorrow.<br/>It's a paradise that overflows with love and vibrant life.");
+				Msg("The ancient legend says that when we understand<br/>the true will of Aton Cimeni, the creator of all things,<br/>then Tir Na Nog will descend upon us as a true paradise.<br/>It is said that no one has ever set a foot in Tir Na Nog...");
+				break;
+
+			case "mabinogi":
+				Msg("Did you know there were epic battles fought between humans and the evil Fomors many ages ago?<br/>I suppose you are too preoccupied wrestling the creatures in the dungeons<br/>to realize how horrific the Fomors were...<br/>At that time, it was terrifying.");
+				Msg("No matter how many humans fought <br>and no matter how much more advanced our weapons were,<br/>we were no match for the sheer power of the Fomors.<br/>So many people lost their lives...");
+				Msg("Despite terrible odds, we never gave up.<br/>Heroes appeared and courageously fought for us,<br/>finally defeating the Fomors with the blessings of the Gods.<br/>Humans were finally able to reclaim their land.");
+				Msg("Erinn, the world we live in now, was defended with the blood of those herioc warriors.<br/>Bards sang songs about them, and everyday folk spread their stories to other lands.<br/>That is the Mabinogi, the song and stories we treasure today.<br/>It's the song written as a tribute to our brave heroes.");
+				break;
+
+			case "musicsheet":
+				GiveKeyword("shop_misc");
+				Msg("For Music Scores, go to the General Shop and talk to Malcolm.<br/>But don't think that Malcolm composes a lot of music!<br/>He has terrible rhythm! He just sells the scrolls on behalf of the composers.");
+				break;
+
 			default:
 				RndFavorMsg(
 					"Hm?",
@@ -378,7 +443,7 @@ public class DuncanBaseScript : NpcScript
 					"I think it'd be better for you to ask someone else."
 				);
 
-				ModifyRelation(0, 0, Random(2));
+				ModifyRelation(0, 0, Random(3));
 				break;
 		}
 	}


### PR DESCRIPTION
The next batch of Tir NPC updates. See a complete change list below:

• added gift weights
• added "who Saved the Goddess" (11001) responses
• added missing adv. keywords
• added missing Phrases in meven
• changed npc name to `<npcname/>` (except Deian)
• changed all title checks to Title instead of
Player.Titles.SelectedTitle
• changed intros for #241
• updated a couple keywords that had additional checks (like Ferghus's
shop_headman keyword and Duncan's personal_info)
• fixed some keywords being added (some were removed for not being
official, some added since they were missing)
• fixed ModifyRelation values
• removed "base" in class name