### PR TITLE
Updated Endelyon, Ferghus, and Goro

### DIFF
--- a/system/scripts/npcs/tir/endelyon.cs
+++ b/system/scripts/npcs/tir/endelyon.cs
@@ -14,6 +14,7 @@ public class EndelyonScript : NpcScript
 		SetFace(skinColor: 17);
 		SetStand("human/female/anim/female_natural_stand_npc_Endelyon");
 		SetLocation(1, 5975, 36842, 0);
+		SetGiftWeights(beauty: 2, individuality: 1, luxury: 1, toughness: 0, utility: 0, rarity: 0, meaning: 2, adult: 0, maniac: 0, anime: 0, sexy: -1);
 
 		EquipItem(Pocket.Face, 3900, 0x00F49D31, 0x00605765, 0x0000B8C3);
 		EquipItem(Pocket.Hair, 3022, 0x005E423E, 0x005E423E, 0x005E423E);
@@ -30,10 +31,7 @@ public class EndelyonScript : NpcScript
 	{
 		SetBgm("NPC_Endelyon.mp3");
 
-		await Intro(
-			"An elegant young woman in the simple black dress of a",
-			"Lymilark priestess stands in front of the church."
-		);
+		await Intro(L("An elegant young woman in the simple black dress of a<br/>Lymilark priestess stands in front of the church."));
 
 		// May I help you on anything else?<button title='End Conversation' keyword='@end' />
 		Msg("May I help you?", Button("Start a Conversation", "@talk"), Button("Shop", "@shop"), Button("Modify Item", "@upgrade"));
@@ -72,8 +70,15 @@ public class EndelyonScript : NpcScript
 					}
 				}
 
-				if (Title == 11002)
+				if (Title == 11001)
+				{
+					Msg("So you rescued Morrighan the goddess, <username/>?<br/>But the goddess is supposed to be at Tir Na Nog.<br/>Does that mean you've been to Tir Na Nog, <username/>?");
+					Msg("Hmm... Well, then, that must mean that I am right now talking to an extraordinary individual, aren't I? Haha.");
+				}
+				else if (Title == 11002)
+				{
 					Msg("I already heard the news! You became the Guardian of Erinn.<br/>The whole town seems to be talking about it. Hehe...<br/>Congratulations!");
+				}
 
 				await Conversation();
 				break;
@@ -139,14 +144,14 @@ public class EndelyonScript : NpcScript
 		{
 			case "personal_info":
 				GiveKeyword("temple");
-				Msg("I don't have much knowledge, but I am here if you need help.");
-				ModifyRelation(Random(2), 0, Random(2));
+				Msg(FavorExpression(), "I don't have much knowledge, but I am here if you need help.");
+				ModifyRelation(Random(2), 0, Random(3));
 				break;
 
 			case "rumor":
 				GiveKeyword("shop_healing");
-				Msg("<face name='normal'/>Have you met Dilys? She's the town's Healer.<br/>Walk along the road heading northeast, and you will find the Healer's House.<br/>Make sure to meet her if you pass by there.");
-				ModifyRelation(Random(2), 0, Random(2));
+				Msg(FavorExpression(), "Have you met Dilys? She's the town's Healer.<br/>Walk along the road heading northeast, and you will find the Healer's House.<br/>Make sure to meet her if you pass by there.");
+				ModifyRelation(Random(2), 0, Random(3));
 				break;
 
 			case "about_skill":
@@ -220,7 +225,7 @@ public class EndelyonScript : NpcScript
 						RemoveKeyword("skill_composing");
 						Msg("What? Bebhinn told you to ask me about the Composing skill?<br/>I like composing music, sure, but I started not too long ago.<br/>I can't even imagine how I could actually teach someone.");
 						Msg("Hmm... Now that we're talking about composing music,<br/>would you do me a favor?");
-						Msg("<title name='NONE'/>(Received a Quest Scroll containing Endelyon's request.)");
+						Msg(Hide.Name, "(Received a Quest Scroll containing <npcname/>'s request.)");
 					}
 					else
 					{
@@ -258,7 +263,7 @@ public class EndelyonScript : NpcScript
 				break;
 
 			case "pool":
-				GiveKeyword("windmill");
+				GiveKeyword("farmland");
 				Msg("The reservoir is near here.<br/>The Windmill draws water out of the reservoir to irrigate the farmland.");
 				break;
 
@@ -315,6 +320,7 @@ public class EndelyonScript : NpcScript
 				break;
 
 			case "shop_bookstore":
+				GiveKeyword("shop_misc");
 				Msg("Are you looking for a bookstore?<br/>Unfortunately, there are no bookstores in this town.<br/>Books are expensive and take time to read,<br/>so they are only for people with spare time and money.");
 				Msg("People here are simply too busy trying to make ends meet.<br/>The only books you can find in this town are probably some books on spells, I guess.<br/>Sometimes, Ferghus or Ranald give books as presents<br/>but it's a stretch to call them real books.");
 				break;
@@ -328,9 +334,17 @@ public class EndelyonScript : NpcScript
 				Msg("Have you been to Duncan's house? The graveyard is right behind it.<br/>It may look a little creepy,<br/>but it's the resting place for the people who died defending Tir Chonaill.<br/>Oh, there are some big spiders roaming around the graveyard. Be careful.");
 				break;
 
+			case "bow":
+				GiveKeyword("show_smith");
+				Msg("Bows?<br/>Well, the Blacksmith's Shop might have them.<br/>Bows are usually made of wood, but arrowheads are made of iron, so...");
+				break;
+
 			case "lute":
-				GiveKeyword("shop_misc");
 				Msg("The lute is a musical instrument with a neck and musical strings attached to a deep, round soundbox.<br/>To play it, simply pluck the strings.<br/>It's an easily accessible instrument. You should try it!<br/>You can find one at Malcolm's General Shop.");
+				break;
+
+			case "complicity":
+				Msg("I have no idea why people do that, but I'm afraid anyone who does such things often<br/>may lose divine protection despite love and blessings from Lymilark.");
 				break;
 
 			case "tir_na_nog":
@@ -354,7 +368,7 @@ public class EndelyonScript : NpcScript
 					"I guess you'd better ask someone else about such things.",
 					"I don't think I can help you with that. Can we talk about something else?"
 				);
-				ModifyRelation(0, 0, Random(2));
+				ModifyRelation(0, 0, Random(3));
 				break;
 		}
 	}

--- a/system/scripts/npcs/tir/ferghus.cs
+++ b/system/scripts/npcs/tir/ferghus.cs
@@ -14,6 +14,7 @@ public class FerghusScript : NpcScript
 		SetFace(skinColor: 23, eyeType: 3, eyeColor: 112, mouthType: 4);
 		SetStand("human/male/anim/male_natural_stand_npc_Ferghus_retake");
 		SetLocation(1, 18075, 29960, 80);
+		SetGiftWeights(beauty: -1, individuality: 0, luxury: 0, toughness: 2, utility: 1, rarity: 1, meaning: 0, adult: 0, maniac: 0, anime: 0, sexy: 2);
 
 		EquipItem(Pocket.Face, 4950, 0x00C6C561, 0x00E1C210, 0x00E8A14A);
 		EquipItem(Pocket.Hair, 4153, 0x002E303F, 0x002E303F, 0x002E303F);
@@ -38,11 +39,7 @@ public class FerghusScript : NpcScript
 	{
 		SetBgm("NPC_Ferghus.mp3");
 
-		await Intro(
-			"His bronze complexion shines with the glow of vitality. His distinctive facial outline ends with a strong jaw line covered with dark beard.",
-			"The first impression clearly shows he is a seasoned blacksmith with years of experience.",
-			"The wide-shouldered man keeps humming with a deep voice while his muscular torso swings gently to the rhythm of the tune."
-		);
+		await Intro(L("His bronze complexion shines with the glow of vitality. His distinctive facial outline ends with a strong jaw line covered with dark beard.<br/>The first impression clearly shows he is a seasoned blacksmith with years of experience.<br/>The wide-shouldered man keeps humming with a deep voice while his muscular torso swings gently to the rhythm of the tune."));
 
 		Msg("Welcome to my Blacksmith's Shop.", Button("Start a Conversation", "@talk"), Button("Shop", "@shop"), Button("Repair Item", "@repair"), Button("Modify Item", "@upgrade"));
 
@@ -51,11 +48,19 @@ public class FerghusScript : NpcScript
 			case "@talk":
 				Greet();
 				Msg(Hide.Name, GetMoodString(), FavorExpression());
-				if (Title == 11002)
+
+				if (Title == 11001)
+				{
+					Msg("...Hmm... Such a boast should be made in front of Priest Meven.<br/>If you'd like, I'll tell you one more thing.");
+					Msg("There's no need to seek out any Goddesses.<br/>Your mother is the true Goddess.");
+					Msg("...Be a good child and honor your mother.");
+				}
+				else if (Title == 11002)
 				{
 					Msg("Hm... <username/>, the Guardian of Erinn?<br/>If you want, I could guard your weapons.");
 					Msg("...If you have any weapons that<br/>have become dull, I'll take care of it...");
 				}
+
 				await Conversation();
 				break;
 
@@ -92,12 +97,16 @@ public class FerghusScript : NpcScript
 								"Finished 1 point repair."
 							);
 						else
-							Msg("Hmm... The repair didn't go well. Sorry...");
+							Msg("Hmm... The repair didn't go well. Sorry..."); // Should be 3
 					}
 					else if (result.Points > 1)
 					{
 						if (result.Fails == 0)
-							Msg("Alright! It's perfectly repaired.");
+							RndMsg(
+								"Alright! It's perfectly repaired.",
+								"Here, full repair is done.",
+								"It's repaired perfectly."
+							);
 						else
 							// TODO: Use string format once we have XML dialogues.
 							Msg("Repair is over.<br/>Unfortunately, I made " + result.Fails + " mistake(s).<br/>Only " + result.Successes + " point(s) got repaired.");
@@ -128,7 +137,7 @@ public class FerghusScript : NpcScript
 				break;
 		}
 
-		End("Goodbye, Ferghus. I'll see you later!");
+		End("Goodbye, <npcname/>. I'll see you later!");
 	}
 
 	private void Greet()
@@ -162,15 +171,16 @@ public class FerghusScript : NpcScript
 		switch (keyword)
 		{
 			case "personal_info":
-				Msg("I'm the blacksmith of Tir Chonaill. We'll see each other often, <username/>.");
-				ModifyRelation(Random(2), 0, Random(2));
+				GiveKeyword("shop_smith");
+				Msg(FavorExpression(), "I'm the blacksmith of Tir Chonaill. We'll see each other often, <username/>.");
+				ModifyRelation(Random(2), 0, Random(3));
 				break;
 
 			case "rumor":
 				GiveKeyword("windmill");
-				Msg("The wind around Tir Chonaill is very strong. It even breaks the windmill blades.<br/>And I'm the one to fix them.<br/>Malcolm's got some skills,<br/>but I'm the one who deals with iron.");
+				Msg(FavorExpression(), "The wind around Tir Chonaill is very strong. It even breaks the windmill blades.<br/>And I'm the one to fix them.<br/>Malcolm's got some skills,<br/>but I'm the one who deals with iron.");
 				Msg("I made those extra blades out there just in case.<br/>When the Windmill stops working, it's really inconvenient around here.<br/>It's always better to be prepared, isn't it?");
-				ModifyRelation(Random(2), 0, Random(2));
+				ModifyRelation(Random(2), 0, Random(3));
 				break;
 
 			case "about_skill":
@@ -218,12 +228,6 @@ public class FerghusScript : NpcScript
 
 			case "skill_range":
 				Msg("I think Ranald knows better.<br/>Why don't you ask him directly?<br/>It's true I make good bows.<br/>But making it and using it is totally different, you know.");
-				break;
-
-			case "bow":
-				RemoveKeyword("bow");
-				RemoveKeyword("skill_range");
-				Msg("Ha, ha. You are looking for bows. You came to the right place.<br/>I certainly have bows. In fact, you know what?<br/>This is a great chance to get your own bow!<br/>By the way, you know that you need arrows too, right?<br/>I mean, what can we do with just a bow and a string?<br/>Play with it?");
 				break;
 
 			case "skill_instrument":
@@ -290,9 +294,16 @@ public class FerghusScript : NpcScript
 				break;
 
 			case "shop_headman":
-				Msg("You are looking for the Chief's House?<br/>His house is near the Square.<br/>Did you come straight down here<br/>without dropping by his place?");
-				Msg("Then you didn't read the Quest Scroll?<br/>No, no. You should've read that.");
-				Msg("Someone worked hard to create that scroll.<br/>Read it and do what it says. You've got nothing to lose.<br/>haha.");
+				if (Player.IsHuman)
+				{
+					Msg("You are looking for the Chief's House?<br/>His house is near the Square.<br/>Did you come straight down here<br/>without dropping by his place?");
+					Msg("Then you didn't read the Quest Scroll?<br/>No, no. You should've read that.");
+					Msg("Someone worked hard to create that scroll.<br/>Read it and do what it says. You've got nothing to lose.<br/>haha.");
+				}
+				else
+				{
+					Msg("You're looking for the Chief's house?<br/>The Chief's house is right next to the town square...<br/>Don't come toward here from the town square,<br/>but go up the other way. Hehehe...");
+				}
 				break;
 
 			case "temple":
@@ -354,9 +365,33 @@ public class FerghusScript : NpcScript
 				Msg("Based on what I've seen, all you need<br/>is a Fishing Rod and a Bait Tin in each hand.");
 				break;
 
+			case "bow":
+				RemoveKeyword("bow");
+				RemoveKeyword("skill_range");
+				Msg("Ha, ha. You are looking for bows. You came to the right place.<br/>I certainly have bows. In fact, you know what?<br/>This is a great chance to get your own bow!<br/>By the way, you know that you need arrows too, right?<br/>I mean, what can we do with just a bow and a string?<br/>Play with it?");
+				break;
+
 			case "lute":
 				GiveKeyword("shop_misc");
 				Msg("Malcolm's General Shop sells lutes.<br/>He also sells... Um...<br/>What was that called? Ukul... something.");
+				break;
+
+			case "complicity":
+				Msg("Um... An instigator? Well...");
+				break;
+
+			case "tir_na_nog":
+				Msg("Hmm... You're interested in legends too?<br/>I'm not such a good storyteller.<br/>You can ask the Chief over there,<br/>or go to Priest Meven.");
+				break;
+
+			case "mabinogi":
+				Msg("A bard's song? Oh, good.<br/>You can enjoy music much better with drinks.<br/>What do you think?");
+				Msg("Hmm... But minors aren't supposed to drink...");
+				break;
+
+			case "musicsheet":
+				GiveKeyword("shop_misc");
+				Msg("If you are looking for Music Scores, you came too far down.<br/>Malcolm's General Shop is near the Square.<br/>Looks like someone wasted their time, haha.");
 				break;
 
 			default:
@@ -367,7 +402,7 @@ public class FerghusScript : NpcScript
 					"That's not my concern.",
 					"I don't know, man. That's just out of my league."
 				);
-				ModifyRelation(0, 0, Random(2));
+				ModifyRelation(0, 0, Random(3));
 				break;
 		}
 	}

--- a/system/scripts/npcs/tir/goro.cs
+++ b/system/scripts/npcs/tir/goro.cs
@@ -13,6 +13,7 @@ public class GoroScript : NpcScript
 		SetBody(height: 0.3f);
 		SetFace(skinColor: 32, eyeType: 3, eyeColor: 7, mouthType: 2);
 		SetLocation(28, 1283, 3485, 198);
+		SetGiftWeights(beauty: 1, individuality: 2, luxury: -1, toughness: 2, utility: 2, rarity: 0, meaning: -1, adult: 2, maniac: -1, anime: 2, sexy: 0);
 
 		EquipItem(Pocket.Shoe, 17005, 0x00441A19, 0x00695C66, 0x0000BADB);
 		EquipItem(Pocket.RightHand1, 40007, 0x006A6A6A, 0x00745D2F, 0x00737270);
@@ -26,11 +27,7 @@ public class GoroScript : NpcScript
 
 	protected override async Task Talk()
 	{
-		await Intro(
-			"With his rough skin, menacing face, and his constant hard-breathing,",
-			"he has the sure look of a Goblin.<br/>Yet, there is something different about this one.",
-			"Strangely, it appears to have a sense of noble demeanor that does not match its rugged looks."
-		);
+		await Intro(L("With his rough skin, menacing face, and his constant hard-breathing,<br/>he has the sure look of a Goblin.<br/>Yet, there is something different about this one.<br/>Strangely, it appears to have a sense of noble demeanor that does not match its rugged looks."));
 
 		Msg("How can I help you?", Button("Start a Conversation", "@talk"), Button("Shop", "@shop"));
 
@@ -38,7 +35,18 @@ public class GoroScript : NpcScript
 		{
 			case "@talk":
 				Greet();
-				Msg("I'm so glad to see you again.<br/>I am Goro, the goblin who can speak the language of humans.");
+
+				if (Title == 11001)
+				{
+					Msg("...Did you finally succeed?<br/>That's incredible. Haha.");
+					Msg("But... Honestly, I believe all this is just the beginning.<br/>Puhahahaha...");
+				}
+				else if (Title == 11002)
+				{
+					Msg("The power of humans is truly amazing...<br/>You're already strong enough to protect Erinn...");
+					Msg("...<npcname/> is quite curious<br/>where humans<br/>get such strength...");
+				}
+
 				await StartConversation();
 				break;
 
@@ -48,7 +56,7 @@ public class GoroScript : NpcScript
 				return;
 		}
 
-		End("Goodbye, Goro. I'll see you later!");
+		End("Goodbye, <npcname/>. I'll see you later!");
 	}
 
 	private void Greet()
@@ -125,6 +133,7 @@ public class GoroScript : NpcScript
 			"Hmm...I believe I have heard about it...",
 			"I do not know anything about that kind of story."
 		);
+		ModifyRelation(0, 0, Random(3));
 	}
 }
 


### PR DESCRIPTION
The next batch of Tir NPC updates. See a complete change list below:

• added gift weights
• added "who Saved the Goddess" (11001) responses
• added missing adv. keywords
• added missing Phrases in meven
• changed npc name to `<npcname/>` (except Deian)
• changed all title checks to Title instead of
Player.Titles.SelectedTitle
• changed intros for #241
• updated a couple keywords that had additional checks (like Ferghus's
shop_headman keyword and Duncan's personal_info)
• fixed some keywords being added (some were removed for not being
official, some added since they were missing)
• fixed ModifyRelation values
• removed "base" in class name