### PR TITLE
Updated Lassar, Malcolm, and Meven

### DIFF
--- a/system/scripts/npcs/tir/lassar.cs
+++ b/system/scripts/npcs/tir/lassar.cs
@@ -1,7 +1,7 @@
 //--- Aura Script -----------------------------------------------------------
-// Lassar, the Magic Instructor in Tir Chonaill
+// Lassar
 //--- Description -----------------------------------------------------------
-// 
+// The Magic Instructor in Tir Chonaill School
 //---------------------------------------------------------------------------
 
 public class LassarScript : NpcScript
@@ -14,6 +14,7 @@ public class LassarScript : NpcScript
 		SetFace(skinColor: 15, eyeType: 153, eyeColor: 25, mouthType: 2);
 		SetStand("human/female/anim/female_natural_stand_npc_lassar02");
 		SetLocation(9, 2020, 1537, 202);
+		SetGiftWeights(beauty: 2, individuality: 0, luxury: 2, toughness: 0, utility: 0, rarity: 0, meaning: 2, adult: 1, maniac: 0, anime: 0, sexy: 2);
 
 		EquipItem(Pocket.Face, 3900, 0x0087C5EC, 0x00D5E029, 0x0001945D);
 		EquipItem(Pocket.Hair, 3144, 0x00D25D5D, 0x00D25D5D, 0x00D25D5D);
@@ -39,11 +40,7 @@ public class LassarScript : NpcScript
 	{
 		SetBgm("NPC_Lassar.mp3");
 
-		await Intro(
-			"Waves of her red hair come down to her shoulders.",
-			"Judging by her somewhat small stature, well-proportioned body, and a neat two-piece school uniform, it isn't hard to tell that she is a teacher.",
-			"The intelligent look in her eyes, the clear lip line and eyebrows present her as a charming lady."
-		);
+		await Intro(L("Waves of her red hair come down to her shoulders.<br/>Judging by her somewhat small stature, well-proportioned body, and a neat two-piece school uniform, it isn't hard to tell that she is a teacher.<br/>The intelligent look in her eyes, the clear lip line and eyebrows present her as a charming lady."));
 
 		Msg("Is there anything I can help you with?", Button("Start a Conversation", "@talk"), Button("Shop", "@shop"), Button("Repair Item", "@repair"), Button("Upgrade item", "@upgrade"));
 
@@ -67,8 +64,12 @@ public class LassarScript : NpcScript
 						Msg(L("Hahaha. I was wondering who you were.<br/>You must be Malcolm's friend, <username/>, right?<br/>I would like to give you this MP Potion.<br/>Will you accept it?"));
 					}
 				}
-
-				if (Title == 11002)
+				else if (Title == 11001)
+				{
+					Msg("Hmm... So you rescued the Goddess?<br/>And... that means you've done something the Three Missing Warriors couldn't do, right?<br/>This is a bit hard to believe. Hahaha...");
+					Msg("If you saved the Goddess, why hasn't she descend down upon Erinn as of yet?");
+				}
+				else if (Title == 11002)
 				{
 					Msg("Hm? <username/>, you're the Guardian of Erinn?<br/>Are you <username/>, the one<br/>who used to train magic and combat here?");
 					Msg("...Wow... I'm amazed.<br/>I never knew a day like this would come.");
@@ -109,14 +110,18 @@ public class LassarScript : NpcScript
 								"You have repaired 1 point."
 							);
 						else
-							Msg("There's been some mistakes.");
+							RndMsg( // Should be 3
+								"There's been some mistakes.",
+								"Repair has been finished, but I made some mistakes."
+							);
 					}
 					else if (result.Points > 1)
 					{
 						if (result.Fails == 0)
 							RndMsg(
 								"I didn't make any mistakes. Hehe",
-								"It has been repaired perfectly!"
+								"It has been repaired perfectly!",
+								"It have been repaired completely. Hehe" // 100% Official http://i.imgur.com/GQH4uOT.png
 							);
 						else
 						{
@@ -186,14 +191,16 @@ public class LassarScript : NpcScript
 		switch (keyword)
 		{
 			case "personal_info":
-				Msg("<npcname/> means 'flame'.<br/>My mother gave birth to me after having dreamed about a wildfire burning the field.");
-				ModifyRelation(Random(2), 0, Random(2));
+				GiveKeyword("school");
+				Msg(FavorExpression(), "<npcname/> means 'flame'.<br/>My mother gave birth to me after having dreamed about a wildfire burning the field.");
+				ModifyRelation(Random(2), 0, Random(3));
 				break;
 
 			case "rumor":
-				Msg("Farmland is just to the south of the School.<br/>They mainly grow wheat or barley, and the crop yields are enough<br/>for the people in Tir Chonaill.<br/>But I think there will be a shortage if travelers stay longer.");
+				GiveKeyword("farmland");
+				Msg(FavorExpression(), "Farmland is just to the south of the School.<br/>They mainly grow wheat or barley, and the crop yields are enough<br/>for the people in Tir Chonaill.<br/>But I think there will be a shortage if travelers stay longer.");
 				Msg("That means no stealing crops for you!");
-				ModifyRelation(Random(2), 0, Random(2));
+				ModifyRelation(Random(2), 0, Random(3));
 				break;
 
 			case "about_skill":
@@ -358,9 +365,33 @@ public class LassarScript : NpcScript
 				Msg("That's why it's great fun to take turns<br/>going there and find items at night to test your guts.");
 				break;
 
+			case "bow":
+				Msg("You can buy a bow at the Blacksmith's Shop.<br/>In this town, weapons are usually sold there.");
+				Msg("Hmm. By the way, why should I inform you of something like this?<br/>Doesn't Ranald tell you things like this?<br/>... Perhaps he looks down on me 'cause I'm a woman...");
+				Msg("Oh, forget I said that. Hehehehe");
+				break;
+
 			case "lute":
 				Msg("A lute?<br/>Malcolm at the General Shop sells lutes.<br/>I guess Priestess Endelyon talked to you,<br/>but you came the wrong way.");
 				Msg("Go in the opposite direction and go toward the Square.<br/>A lute will be useful in many ways.");
+				break;
+
+			case "tir_na_nog":
+				Msg("Hmm... When I was young, I heard town folks say<br/>that Tir Na Nog was simply an utopia.<br/>But what I learned at Emain Macha<br/>was different.");
+				Msg("Tir Na Nog is a lofty world of magic<br/>and of life where<br/>the powers of Gods and of magic are united.");
+				Msg("Of course, I am not sure<br/>whether I fully understand what it means.<br/>But then, who else would?");
+				Msg("I think it is a world<br/>well beyond my imagination...");
+				break;
+
+			case "mabinogi":
+				Msg("You seem fairly interested in Mabinogi.<br/>As far as legends about swords and magic are concerned,<br/>it is better to learn from word of mouth than from dry books.");
+				Msg("As you know, when a story moves on from people to people,<br/>it is naturally exaggerated<br/>with its original meaning distorted.");
+				Msg("One of the best ways to keep the original form of<br/>a story intact is to preserve it through music.");
+				Msg("Of course, that doesn't mean<br/>that the story is delivered in exactly the same form.<br/>But it would be helpful for you to understand Mabinogi this way.");
+				break;
+
+			case "musicsheet":
+				Msg("If you want Music Scores, you should go to Malcolm's General Shop.<br/>Of course, they aren't free. There is no such thing as a free lunch.");
 				break;
 
 			case "jewel":
@@ -375,7 +406,7 @@ public class LassarScript : NpcScript
 					"Why don't you ask other people? I am afraid I would be of little help.",
 					"I thought I knew. But it is more difficult to actually explain it than I thought."
 				);
-				ModifyRelation(0, 0, Random(2));
+				ModifyRelation(0, 0, Random(3));
 				break;
 		}
 	}

--- a/system/scripts/npcs/tir/malcolm.cs
+++ b/system/scripts/npcs/tir/malcolm.cs
@@ -14,6 +14,7 @@ public class MalcolmScript : NpcScript
 		SetFace(skinColor: 16, eyeType: 26, eyeColor: 162);
 		SetStand("human/male/anim/male_natural_stand_npc_malcolm_retake", "human/male/anim/male_natural_stand_npc_malcolm_talk");
 		SetLocation(8, 1238, 1655, 59);
+		SetGiftWeights(beauty: 2, individuality: -1, luxury: 0, toughness: 0, utility: 1, rarity: 2, meaning: 0, adult: 0, maniac: 0, anime: 0, sexy: 0);
 
 		EquipItem(Pocket.Face, 4900, 0x00FFB859, 0x003C6274, 0x00505968);
 		EquipItem(Pocket.Hair, 4155, 0x00ECBC58, 0x00ECBC58, 0x00ECBC58);
@@ -32,12 +33,7 @@ public class MalcolmScript : NpcScript
 	{
 		SetBgm("NPC_Malcolm.mp3");
 
-		await Intro(
-			"While his thin face makes him look weak,",
-			"and his soft and delicate hands seem much too feminine,",
-			"his cool long blonde hair gives him a suave look.",
-			"He looks like he just came out of a workshop since he's wearing a heavy leather apron."
-		);
+		await Intro(L("While his thin face makes him look weak,<br/>and his soft and delicate hands seem much too feminine,<br/>his cool long blonde hair gives him a suave look.<br/>He looks like he just came out of a workshop since he's wearing a heavy leather apron."));
 
 		Msg("What can I do for you?", Button("Start a Conversation", "@talk"), Button("Shop", "@shop"), Button("Repair Item", "@repair"));
 
@@ -85,7 +81,13 @@ public class MalcolmScript : NpcScript
 					}
 				}
 
-				if (Title == 11002)
+				if (Title == 11001)
+				{
+					Msg("...");
+					Msg("...*Sigh*");
+					Msg("Has your life gotten any better after saving the Goddess?");
+				}
+				else if (Title == 11002)
 				{
 					Msg("You're the... Guardian of Erinn?<br/>I don't know what you do exactly,<br/>but you seem to leave<br/>a really good impression on people.");
 					Msg("...I'm a bit jealous...");
@@ -185,14 +187,14 @@ public class MalcolmScript : NpcScript
 		{
 			case "personal_info":
 				GiveKeyword("shop_misc");
-				Msg("I run this General Shop. I sell various goods.");
-				ModifyRelation(Random(2), 0, Random(2));
+				Msg(FavorExpression(), "I run this General Shop. I sell various goods.");
+				ModifyRelation(Random(2), 0, Random(3));
 				break;
 
 			case "rumor":
-				Msg("Tir Chonaill is a peaceful town.<br/>So when something happens, everyone in the town knows it right away.<br/>I warn you, some were humiliated because of that...<br/>Nothing is as important as being responsible for your own actions.");
+				Msg(FavorExpression(), "Tir Chonaill is a peaceful town.<br/>So when something happens, everyone in the town knows it right away.<br/>I warn you, some were humiliated because of that...<br/>Nothing is as important as being responsible for your own actions.");
 				Msg("If you behave like Tracy, you'll be in big trouble.");
-				ModifyRelation(Random(2), 0, Random(2));
+				ModifyRelation(Random(2), 0, Random(3));
 				break;
 
 			case "about_skill":
@@ -297,6 +299,7 @@ public class MalcolmScript : NpcScript
 				break;
 
 			case "farmland":
+				GiveKeyword("school");
 				Msg("The farmland is near the School.<br/>How come so many travelers are interested in it?<br/>There's nothing special about it.");
 				Msg("What's more, their careless strolls through the farmland<br/>are damaging the crops...");
 				break;
@@ -374,6 +377,37 @@ public class MalcolmScript : NpcScript
 				Msg("You can buy them here,<br/>so take a look if you're interested in fishing.");
 				break;
 
+			case "bow":
+				GiveKeyword("shop_smith");
+				Msg("A bow? Well... I could make and sell them...<br/>Actually, I did sell them before, but I felt bad for Ferghus<br/>so I just stopped selling them.");
+				Msg("You should just go to Ferghus' Blacksmith's Shop.<br/>After all, you need to buy arrows,<br/>and bows are useless without them.");
+				break;
+
+			case "lute":
+				Msg("A lute? You have an elegant hobby.<br/>I do sell lutes but they aren't of the highest quality...<br/>Would you like to buy one anyway?");
+				Msg("Press 'Shop', then.");
+				break;
+
+			case "complicity":
+				Msg("Um... What are you talking about?");
+				break;
+
+			case "tir_na_nog":
+				Msg("You mean, the legendary story passed down for generations of a paradise,<br/>where people stay young and live in total bliss?");
+				Msg("Ah! I read it in a book.<br/>I like books a lot.");
+				break;
+
+			case "mabinogi":
+				Msg("Mabinogi, huh?<br/>Well, I may know a lot about some things,<br/>but older people would know more about that.<br/>I'm sure of it.");
+				Msg("I suggest asking Chief Duncan<br/>or Ferghus.");
+				break;
+
+			case "musicsheet":
+				Msg("Yes, you came to the right place.<br/>I sell them.");
+				Msg("...");
+				Msg("But then, you should have pressed 'Shop',<br/>not talk with me...");
+				break;
+
 			default:
 				RndMsg(
 					"I don't know.",
@@ -383,7 +417,7 @@ public class MalcolmScript : NpcScript
 					"NPCs don't have a conversation book.<br/>So I won't remember the things you told me...",
 					"Sorry, I don't know.<br/>Hm... Maybe I should have a travel diary to write things down."
 				);
-				ModifyRelation(0, 0, Random(2));
+				ModifyRelation(0, 0, Random(3));
 				break;
 		}
 	}

--- a/system/scripts/npcs/tir/meven.cs
+++ b/system/scripts/npcs/tir/meven.cs
@@ -13,25 +13,30 @@ public class MevenScript : NpcScript
 		SetFace(skinColor: 21, eyeType: 5, eyeColor: 27);
 		SetStand("human/male/anim/male_natural_stand_npc_Meven");
 		SetLocation(4, 954, 2271, 198);
+		SetGiftWeights(beauty: 1, individuality: 0, luxury: -1, toughness: 0, utility: 2, rarity: 0, meaning: 2, adult: 1, maniac: 0, anime: 0, sexy: 0);
 
 		EquipItem(Pocket.Face, 4900, 0x00D45D8D, 0x0087178A, 0x0024AF7C);
 		EquipItem(Pocket.Hair, 4026, 0x00EBE0C0, 0x00EBE0C0, 0x00EBE0C0);
 		EquipItem(Pocket.Armor, 15006, 0x00313727, 0x00282C2B, 0x00F0DA4A);
 		EquipItem(Pocket.Shoe, 17012, 0x00313727, 0x00FFFFFF, 0x00A0927D);
 
-		AddPhrase("Ah, I forgot I have some plowing to do.");
 		AddPhrase("...");
+		AddPhrase("(Smile)");
+		AddPhrase("!");
+		AddPhrase("?");
+		AddPhrase("??");
+		AddPhrase("???");
+		AddPhrase("Oops! I forgot to iron my robes!");
+		AddPhrase("Ah, I forgot I have some plowing to do.");
+		AddPhrase("Perhaps I could take a quick rest now.");
+		AddPhrase("Hiccup! Hiccup! (Confused)");
 	}
 
 	protected override async Task Talk()
 	{
 		SetBgm("NPC_Meven.mp3");
 
-		await Intro(
-			"Dressed in a robe, this composed man of moderate build maintains a very calm posture.",
-			"Every bit of his appearance and the air surrounding him show that he is unfailingly a man of the clergy.",
-			"Silvery hair frames his friendly face, and his gentle eyes suggest a rather quaint and quiet mood with flashes of hidden humor."
-		);
+		await Intro(L("Dressed in a robe, this composed man of moderate build maintains a very calm posture.<br/>Every bit of his appearance and the air surrounding him show that he is unfailingly a man of the clergy.<br/>Silvery hair frames his friendly face, and his gentle eyes suggest a rather quaint and quiet mood with flashes of hidden humor."));
 
 		Msg("Welcome to the Church of Lymilark.", Button("Start a Conversation", "@talk"));
 
@@ -40,11 +45,19 @@ public class MevenScript : NpcScript
 			case "@talk":
 				Greet();
 				Msg(Hide.Name, GetMoodString(), FavorExpression());
-				if (Player.Titles.SelectedTitle == 11002)
+
+				if (Title == 11001)
+				{
+					Msg("Even Tarlach had failed,<br/>but you managed to do it...<br/>I'd like to congratulate you.");
+					Msg("You saved this world from great danger.<br/>Have confidence in your thoughts and actions,<br/>and try to live up to your reputation.");
+					Msg("...Just a piece of advice for you that should be taken with a pinch of salt.");
+				}
+				else if (Title == 11002)
 				{
 					Msg("...I see...<br/>So you're the one<br/>who prevented Macha from being reborn...");
 					Msg("Good job. <username/>...<br/>The sky is the limit for you<br/>to change this world to a better place...");
 				}
+
 				await Conversation();
 				break;
 		}
@@ -84,13 +97,13 @@ public class MevenScript : NpcScript
 		{
 			case "personal_info":
 				GiveKeyword("temple");
-				Msg("I am Priest <npcname/>.<br/>It's so nice to see someone cares for an old man.<br/>Ha ha.");
-				ModifyRelation(Random(2), 0, Random(2));
+				Msg(FavorExpression(), "I am Priest <npcname/>.<br/>It's so nice to see someone cares for an old man.<br/>Ha ha.");
+				ModifyRelation(Random(2), 0, Random(3));
 				break;
 
 			case "rumor":
-				Msg("The General Shop, Grocery Store and the Bank<br/>surround the Square of the town.<br/>A bit higher up the hill is the Chief's House.");
-				ModifyRelation(Random(2), 0, Random(2));
+				Msg(FavorExpression(), "The General Shop, Grocery Store and the Bank<br/>surround the Square of the town.<br/>A bit higher up the hill is the Chief's House.");
+				ModifyRelation(Random(2), 0, Random(3));
 				break;
 
 			case "about_arbeit":
@@ -260,14 +273,16 @@ public class MevenScript : NpcScript
 				break;
 
 			case "bow":
-				GiveKeyword("shop_smith");
 				Msg("If you need a bow, you can go to the Blacksmith's Shop.<br/>It's not made of iron,<br/>but you would need arrows too.<p/>Go and ask Ferghus.<br/>He is the expert.<p/>Could you perhaps tell him<br/>to stop drinking<br/>and come to the services..?");
 				break;
 
 			case "lute":
-				GiveKeyword("shop_misc");
 				Msg("Are you looking for a lute?<br/>You could get a lute<br/>at Malcolm's General Shop.<br/>Tell him I sent you. Probably you could negotiate over the price.");
 				Msg("Well, he may charge you more, as a matter fact.");
+				break;
+
+			case "complicity":
+				Msg("My Lord!<br/>Please enrich the poor souls of your children, suffering from doubts and suspicions.");
 				break;
 
 			case "tir_na_nog":
@@ -295,7 +310,7 @@ public class MevenScript : NpcScript
 					"I don't think I heard of that, I'm sorry.",
 					"How could I know about that, I'm just a priest."
 				);
-				ModifyRelation(0, 0, Random(2));
+				ModifyRelation(0, 0, Random(3));
 				break;
 		}
 	}


### PR DESCRIPTION
The next batch of Tir NPC updates. See a complete change list below:

• added gift weights
• added "who Saved the Goddess" (11001) responses
• added missing adv. keywords
• added missing Phrases in meven
• changed npc name to `<npcname/>` (except Deian)
• changed all title checks to Title instead of
Player.Titles.SelectedTitle
• changed intros for #241
• updated a couple keywords that had additional checks (like Ferghus's
shop_headman keyword and Duncan's personal_info)
• fixed some keywords being added (some were removed for not being
official, some added since they were missing)
• fixed ModifyRelation values
• removed "base" in class name