### PR TITLE
Implement QuestObjectiveCreate

### DIFF
--- a/src/ChannelServer/Scripting/Scripts/QuestScript.cs
+++ b/src/ChannelServer/Scripting/Scripts/QuestScript.cs
@@ -445,8 +445,10 @@ namespace Aura.Channel.Scripting.Scripts
 
 			if (objective.Type == ObjectiveType.Create)
 			{
-				ChannelServer.Instance.Events.CreatureCreatedItem -= this.OnCreatureCreatedItem;
-				ChannelServer.Instance.Events.CreatureCreatedItem += this.OnCreatureCreatedItem;
+				ChannelServer.Instance.Events.CreatureCreatedItem -= this.OnCreatureCreatedOrProducedItem;
+				ChannelServer.Instance.Events.CreatureCreatedItem += this.OnCreatureCreatedOrProducedItem;
+				ChannelServer.Instance.Events.CreatureProducedItem -= this.OnCreatureCreatedOrProducedItem;
+				ChannelServer.Instance.Events.CreatureProducedItem += this.OnCreatureCreatedOrProducedItem;
 			}
 
 			if (objective.Type == ObjectiveType.ReachRank)
@@ -581,7 +583,7 @@ namespace Aura.Channel.Scripting.Scripts
 		protected QuestObjective Collect(int itemId, int amount) { return new QuestObjectiveCollect(itemId, amount); }
 		protected QuestObjective Talk(string npcName) { return new QuestObjectiveTalk(npcName); }
 		protected QuestObjective Deliver(int itemId, string npcName) { return new QuestObjectiveDeliver(itemId, 1, npcName); }
-		protected QuestObjective Create(int itemId, int amount, CreationMethod method, int quality = -1000) { return new QuestObjectiveCreate(itemId, amount, method, quality); }
+		protected QuestObjective Create(int itemId, int amount, SkillId skillId, int quality = -1000) { return new QuestObjectiveCreate(itemId, amount, skillId, quality); }
 		protected QuestObjective ReachRank(SkillId skillId, SkillRank rank) { return new QuestObjectiveReachRank(skillId, rank); }
 		protected QuestObjective ReachLevel(int level) { return new QuestObjectiveReachLevel(level); }
 		protected QuestObjective GetKeyword(string keyword) { return new QuestObjectiveGetKeyword(keyword); }
@@ -964,9 +966,38 @@ namespace Aura.Channel.Scripting.Scripts
 		/// <summary>
 		/// Updates Create objectives.
 		/// </summary>
-		private void OnCreatureCreatedItem(CreationEventArgs args)
+		/// <remarks>
+		/// Creation and Production events share same event 
+		/// due to having the same ObjectiveType code.
+		/// </remarks>
+		/// <param name="args">An object of type CreationEventArgs or ProductionEventArgs, otherwise an exception will be issued to the logger.</param>
+		private void OnCreatureCreatedOrProducedItem(EventArgs args)
 		{
-			var creature = args.Creature;
+			Creature creature;
+			int itemId;
+			string skill; // Is there a better way to check for skill match?
+
+			CreationEventArgs crargs = args as CreationEventArgs;
+			ProductionEventArgs prargs = args as ProductionEventArgs;
+			if (crargs != null) // Try cast as CreationEventArgs
+			{
+				creature = crargs.Creature;
+				itemId = crargs.Item.Info.Id;
+				skill = crargs.Method.ToString();
+			}
+			else if (prargs != null) // Try cast as ProductionEventArgs
+			{
+				creature = prargs.Creature;
+				itemId = prargs.Item.Info.Id;
+				skill = prargs.ProductionData.Category.ToString();
+				if (skill == "Spinning")
+					skill = "Weaving"; // Shared SkillId.
+			}
+			else // Error: Cannot cast as either one.
+			{
+				Log.Exception(new InvalidCastException(String.Format("Unable to cast EventArgs as CreationEventArgs nor ProductionEventArgs (Quest Name: {0}, ID: {1})", this.Name, this.Id)));
+				return;
+			}
 
 			var quests = creature.Quests.GetAllIncomplete(this.Id);
 			foreach (var quest in quests)
@@ -981,7 +1012,7 @@ namespace Aura.Channel.Scripting.Scripts
 				if (objective == null || objective.Type != ObjectiveType.Create) return;
 
 				var createObjective = (objective as QuestObjectiveCreate);
-				if (!progress.Done && args.Item.Info.Id == createObjective.ItemId && args.Method == createObjective.CreationMethod)
+				if (!progress.Done && itemId == createObjective.ItemId && skill == createObjective.SkillId.ToString())
 				{
 					progress.Count++;
 					if (progress.Count == createObjective.Amount)

--- a/src/ChannelServer/World/EventManager.cs
+++ b/src/ChannelServer/World/EventManager.cs
@@ -386,9 +386,10 @@ namespace Aura.Channel.World
 		}
 	}
 
-	public enum CreationMethod
+	/// <remarks>Can test for equality against SkillId.</remarks>
+	public enum CreationMethod : ushort
 	{
-		Tailoring,
-		Blacksmithing,
+		Tailoring = 10001,
+		Blacksmithing = 10016,
 	}
 }

--- a/src/ChannelServer/World/EventManager.cs
+++ b/src/ChannelServer/World/EventManager.cs
@@ -386,10 +386,9 @@ namespace Aura.Channel.World
 		}
 	}
 
-	/// <remarks>Can test for equality against SkillId.</remarks>
-	public enum CreationMethod : ushort
+	public enum CreationMethod
 	{
-		Tailoring = 10001,
-		Blacksmithing = 10016,
+		Tailoring,
+		Blacksmithing,
 	}
 }

--- a/src/ChannelServer/World/Quests/Objectives.cs
+++ b/src/ChannelServer/World/Quests/Objectives.cs
@@ -274,19 +274,19 @@ namespace Aura.Channel.World.Quests
 	{
 		public override ObjectiveType Type { get { return ObjectiveType.Create; } }
 
-		public CreationMethod CreationMethod { get; private set; }
+		public SkillId SkillId { get; private set; }
 		public int MinQuality { get; private set; }
 		public int ItemId { get; private set; }
 
-		public QuestObjectiveCreate(int itemId, int amount, CreationMethod method, int quality = -1000)
+		public QuestObjectiveCreate(int itemId, int amount, SkillId skillId, int quality = -1000)
 			: base(amount)
 		{
-			this.CreationMethod = method;
+			this.SkillId = skillId;
 			this.MinQuality = quality;
 			this.ItemId = itemId;
 			this.Amount = amount;
 
-			this.MetaData.SetUShort("TGTSKL", (ushort)method);
+			this.MetaData.SetUShort("TGTSKL", (ushort)skillId);
 			this.MetaData.SetInt("TARGETQUALITY", quality);
 			this.MetaData.SetInt("TARGETITEM", itemId);
 			this.MetaData.SetInt("TARGETCOUNT", amount);

--- a/src/ChannelServer/World/Quests/Objectives.cs
+++ b/src/ChannelServer/World/Quests/Objectives.cs
@@ -269,4 +269,27 @@ namespace Aura.Channel.World.Quests
 			this.MetaData.SetString("TGTCLS", dungeonName);
 		}
 	}
+
+	public class QuestObjectiveCreate : QuestObjective
+	{
+		public override ObjectiveType Type { get { return ObjectiveType.Create; } }
+
+		public CreationMethod CreationMethod { get; private set; }
+		public int MinQuality { get; private set; }
+		public int ItemId { get; private set; }
+
+		public QuestObjectiveCreate(int itemId, int amount, CreationMethod method, int quality = -1000)
+			: base(amount)
+		{
+			this.CreationMethod = method;
+			this.MinQuality = quality;
+			this.ItemId = itemId;
+			this.Amount = amount;
+
+			this.MetaData.SetUShort("TGTSKL", (ushort)method);
+			this.MetaData.SetInt("TARGETQUALITY", quality);
+			this.MetaData.SetInt("TARGETITEM", itemId);
+			this.MetaData.SetInt("TARGETCOUNT", amount);
+		}
+	}
 }

--- a/src/Mabi/Const/Quests.cs
+++ b/src/Mabi/Const/Quests.cs
@@ -9,6 +9,7 @@ namespace Aura.Mabi.Const
 		Collect = 2,
 		Talk = 3,
 		Deliver = 4,
+		Create = 8,
 		ReachRank = 9,
 		ClearDungeon = 13,
 		ReachLevel = 15,


### PR DESCRIPTION
Additional resource: [Sample/Test script (gist)](https://gist.github.com/valdeza/a6ea9e16d87b7c70b5b6300faca5ebcf)
Dependent: All production quest objectives (particularly PTJs asking you to tailor or weave something)

Since events `CreatureCreatedItem` and `CreatureProducedItem` share the quest objective type (same byte ID and packet data structure in NewQuest packets), they share the same event handler (`QuestScript.OnCreatureCreatedOrProducedItem()`).

Additional consideration prior to merging: 
Is [using string comparison](https://github.com/valdeza/aura/blob/5c57b9e02442901abc48017da9c99ccbdc7cb4eb/src/ChannelServer/Scripting/Scripts/QuestScript.cs#L978) to check if skill just used matches the target skill on the quest objective acceptable? 
I was thinking of defining another enum, but seeing it was just a union between `ProductionCategory` and `CreationMethod` it seemed rather redundant.
Comparing `ushort`s would have been possible if `ProductionCategory` had not already been defined as `short`s.