### PR TITLE
Bug fix: Do not count WIP items for Collect quest objectives

### DIFF
--- a/src/ChannelServer/Scripting/Scripts/QuestScript.cs
+++ b/src/ChannelServer/Scripting/Scripts/QuestScript.cs
@@ -712,7 +712,7 @@ namespace Aura.Channel.Scripting.Scripts
 
 					case ObjectiveType.Collect:
 						var itemId = (objective as QuestObjectiveCollect).ItemId;
-						var count = creature.Inventory.Count(itemId);
+						var count = creature.Inventory.Count(itemId, false);
 
 						if (!progress.Done && count >= objective.Amount)
 							quest.SetDone(progress.Ident);

--- a/src/ChannelServer/Scripting/Scripts/QuestScript.cs
+++ b/src/ChannelServer/Scripting/Scripts/QuestScript.cs
@@ -712,7 +712,9 @@ namespace Aura.Channel.Scripting.Scripts
 
 					case ObjectiveType.Collect:
 						var itemId = (objective as QuestObjectiveCollect).ItemId;
-						var count = creature.Inventory.Count(itemId);
+
+						// Do not count incomplete items (e.g. tailoring, blacksmithing).
+						var count = creature.Inventory.Count((Item item) => item.Info.Id == itemId && !item.MetaData1.Has("PRGRATE"));
 
 						if (!progress.Done && count >= objective.Amount)
 							quest.SetDone(progress.Ident);

--- a/src/ChannelServer/Scripting/Scripts/QuestScript.cs
+++ b/src/ChannelServer/Scripting/Scripts/QuestScript.cs
@@ -712,7 +712,7 @@ namespace Aura.Channel.Scripting.Scripts
 
 					case ObjectiveType.Collect:
 						var itemId = (objective as QuestObjectiveCollect).ItemId;
-						var count = creature.Inventory.Count(itemId, false);
+						var count = creature.Inventory.Count(itemId);
 
 						if (!progress.Done && count >= objective.Amount)
 							quest.SetDone(progress.Ident);

--- a/src/ChannelServer/World/Inventory/CreatureInventory.cs
+++ b/src/ChannelServer/World/Inventory/CreatureInventory.cs
@@ -1396,12 +1396,13 @@ namespace Aura.Channel.World.Inventory
 		/// Returns the amount of items with this id in the inventory.
 		/// </summary>
 		/// <param name="itemId"></param>
+		/// <param name="includePRGRATE">If true, include tailored or blacksmithed items that are works in progress.</param>
 		/// <returns></returns>
-		public int Count(int itemId)
+		public int Count(int itemId, bool includePRGRATE = true)
 		{
 			lock (_pockets)
 				return _pockets.Values.Where(a => !InvisiblePockets.Contains(a.Pocket))
-					.Sum(pocket => pocket.CountItem(itemId));
+					.Sum(pocket => pocket.CountItem(itemId, includePRGRATE));
 		}
 
 		/// <summary>

--- a/src/ChannelServer/World/Inventory/CreatureInventory.cs
+++ b/src/ChannelServer/World/Inventory/CreatureInventory.cs
@@ -1396,13 +1396,12 @@ namespace Aura.Channel.World.Inventory
 		/// Returns the amount of items with this id in the inventory.
 		/// </summary>
 		/// <param name="itemId"></param>
-		/// <param name="includePRGRATE">If true, include tailored or blacksmithed items that are works in progress.</param>
 		/// <returns></returns>
-		public int Count(int itemId, bool includePRGRATE = true)
+		public int Count(int itemId)
 		{
 			lock (_pockets)
 				return _pockets.Values.Where(a => !InvisiblePockets.Contains(a.Pocket))
-					.Sum(pocket => pocket.CountItem(itemId, includePRGRATE));
+					.Sum(pocket => pocket.CountItem(itemId));
 		}
 
 		/// <summary>

--- a/src/ChannelServer/World/Inventory/CreatureInventory.cs
+++ b/src/ChannelServer/World/Inventory/CreatureInventory.cs
@@ -1418,6 +1418,18 @@ namespace Aura.Channel.World.Inventory
 		}
 
 		/// <summary>
+		/// Returns the amount of items matching the conditions specified.
+		/// </summary>
+		/// <param name="predicate"></param>
+		/// <returns></returns>
+		public int Count(Func<Item, bool> predicate)
+		{
+			lock (_pockets)
+				return _pockets.Values.Where(a => !InvisiblePockets.Contains(a.Pocket))
+					.Sum(pocket => pocket.CountItem(predicate));
+		}
+
+		/// <summary>
 		/// Returns the number of items in the given pocket.
 		/// Returns -1 if the pocket doesn't exist.
 		/// </summary>

--- a/src/ChannelServer/World/Inventory/InventoryPockets.cs
+++ b/src/ChannelServer/World/Inventory/InventoryPockets.cs
@@ -125,9 +125,8 @@ namespace Aura.Channel.World.Inventory
 		/// Returns amount of items by item id.
 		/// </summary>
 		/// <param name="itemId"></param>
-		/// <param name="includePRGRATE">If true, include tailored or blacksmithed items that are works in progress.</param>
 		/// <returns></returns>
-		public abstract int CountItem(int itemId, bool includePRGRATE = true);
+		public abstract int CountItem(int itemId);
 
 		/// <summary>
 		/// Returns amount of items by matching tag.
@@ -462,9 +461,9 @@ namespace Aura.Channel.World.Inventory
 			return result;
 		}
 
-		public override int CountItem(int itemId, bool includePRGRATE = true)
+		public override int CountItem(int itemId)
 		{
-			return _items.Values.Where(item => (item.Info.Id == itemId && (includePRGRATE || !item.MetaData1.Has("PRGRATE"))) || item.Data.StackItemId == itemId)
+			return _items.Values.Where(item => item.Info.Id == itemId || item.Data.StackItemId == itemId)
 				.Aggregate(0, (current, item) => current + item.Info.Amount);
 		}
 
@@ -659,9 +658,9 @@ namespace Aura.Channel.World.Inventory
 			return 0;
 		}
 
-		public override int CountItem(int itemId, bool includePRGRATE = true)
+		public override int CountItem(int itemId)
 		{
-			if (_item != null && _item.Info.Id == itemId && (includePRGRATE || !_item.MetaData1.Has("PRGRATE")))
+			if (_item != null && _item.Info.Id == itemId)
 				return _item.Info.Amount;
 			return 0;
 		}
@@ -775,9 +774,9 @@ namespace Aura.Channel.World.Inventory
 			return 0;
 		}
 
-		public override int CountItem(int itemId, bool includePRGRATE = true)
+		public override int CountItem(int itemId)
 		{
-			return _items.Where(item => (item.Info.Id == itemId && (includePRGRATE || !item.MetaData1.Has("PRGRATE"))) || item.Data.StackItemId == itemId)
+			return _items.Where(item => item.Info.Id == itemId || item.Data.StackItemId == itemId)
 				.Aggregate(0, (current, item) => current + item.Info.Amount);
 		}
 

--- a/src/ChannelServer/World/Inventory/InventoryPockets.cs
+++ b/src/ChannelServer/World/Inventory/InventoryPockets.cs
@@ -125,8 +125,9 @@ namespace Aura.Channel.World.Inventory
 		/// Returns amount of items by item id.
 		/// </summary>
 		/// <param name="itemId"></param>
+		/// <param name="includePRGRATE">If true, include tailored or blacksmithed items that are works in progress.</param>
 		/// <returns></returns>
-		public abstract int CountItem(int itemId);
+		public abstract int CountItem(int itemId, bool includePRGRATE = true);
 
 		/// <summary>
 		/// Returns amount of items by matching tag.
@@ -461,9 +462,9 @@ namespace Aura.Channel.World.Inventory
 			return result;
 		}
 
-		public override int CountItem(int itemId)
+		public override int CountItem(int itemId, bool includePRGRATE = true)
 		{
-			return _items.Values.Where(item => item.Info.Id == itemId || item.Data.StackItemId == itemId)
+			return _items.Values.Where(item => (item.Info.Id == itemId && (includePRGRATE || !item.MetaData1.Has("PRGRATE"))) || item.Data.StackItemId == itemId)
 				.Aggregate(0, (current, item) => current + item.Info.Amount);
 		}
 
@@ -658,9 +659,9 @@ namespace Aura.Channel.World.Inventory
 			return 0;
 		}
 
-		public override int CountItem(int itemId)
+		public override int CountItem(int itemId, bool includePRGRATE = true)
 		{
-			if (_item != null && _item.Info.Id == itemId)
+			if (_item != null && _item.Info.Id == itemId && (includePRGRATE || !_item.MetaData1.Has("PRGRATE")))
 				return _item.Info.Amount;
 			return 0;
 		}
@@ -774,9 +775,9 @@ namespace Aura.Channel.World.Inventory
 			return 0;
 		}
 
-		public override int CountItem(int itemId)
+		public override int CountItem(int itemId, bool includePRGRATE = true)
 		{
-			return _items.Where(item => item.Info.Id == itemId || item.Data.StackItemId == itemId)
+			return _items.Where(item => (item.Info.Id == itemId && (includePRGRATE || !item.MetaData1.Has("PRGRATE"))) || item.Data.StackItemId == itemId)
 				.Aggregate(0, (current, item) => current + item.Info.Amount);
 		}
 

--- a/src/ChannelServer/World/Inventory/InventoryPockets.cs
+++ b/src/ChannelServer/World/Inventory/InventoryPockets.cs
@@ -134,6 +134,13 @@ namespace Aura.Channel.World.Inventory
 		/// <param name="tag"></param>
 		/// <returns></returns>
 		public abstract int CountItem(string tag);
+
+		/// <summary>
+		/// Returns amount of items by specified conditions.
+		/// </summary>
+		/// <param name="predicate"></param>
+		/// <returns></returns>
+		public abstract int CountItem(Func<Item, bool> predicate);
 	}
 
 	/// <summary>
@@ -473,6 +480,12 @@ namespace Aura.Channel.World.Inventory
 				.Aggregate(0, (current, item) => current + item.Info.Amount);
 		}
 
+		public override int CountItem(Func<Item, bool> predicate)
+		{
+			return _items.Values.Where(predicate)
+				.Aggregate(0, (current, item) => current + item.Info.Amount);
+		}
+
 		public override Item GetItem(long id)
 		{
 			Item item;
@@ -672,6 +685,13 @@ namespace Aura.Channel.World.Inventory
 			return 0;
 		}
 
+		public override int CountItem(Func<Item, bool> predicate)
+		{
+			if (_item != null && predicate(_item))
+				return _item.Info.Amount;
+			return 0;
+		}
+
 		public override Item GetItem(long id)
 		{
 			if (_item != null && _item.EntityId == id)
@@ -783,6 +803,12 @@ namespace Aura.Channel.World.Inventory
 		public override int CountItem(string tag)
 		{
 			return _items.Where(item => item.HasTag(tag) || (item.Data.StackItem != null && item.Data.StackItem.HasTag(tag)))
+				.Aggregate(0, (current, item) => current + item.Info.Amount);
+		}
+
+		public override int CountItem(Func<Item, bool> predicate)
+		{
+			return _items.Where(predicate)
 				.Aggregate(0, (current, item) => current + item.Info.Amount);
 		}
 


### PR DESCRIPTION
Collect quest objectives will no longer count production skill works in progress (e.g. half-finished tailored Cores' Healers Dress).

This was solved by adding checks for whether PRGRATE metadata exists on the item to be counted. The modified item counting functions now have an optional bool parametre to specify whether or not to perform PRGRATE checks (made optional to avoid needing to change all count function call sites).