### PR TITLE
Add CreatePattern factory method on Item.cs

### DIFF
--- a/src/ChannelServer/World/Entities/Item.cs
+++ b/src/ChannelServer/World/Entities/Item.cs
@@ -784,6 +784,27 @@ namespace Aura.Channel.World.Entities
 		}
 
 		/// <summary>
+		/// Creates a tailoring pattern/blacksmith manual of the specified form ID and number of uses.
+		/// </summary>
+		/// <remarks>
+		/// It is assumed that a single use subtracts 1000 durability from the pattern. 
+		/// (i.e. <paramref name="useCount"/> is multiplied by 1000 and applied to pattern durability.)
+		/// </remarks>
+		/// <param name="itemId"></param>
+		/// <param name="formId"></param>
+		/// <param name="useCount"></param>
+		/// <returns></returns>
+		public static Item CreatePattern(int itemId, int formId, int useCount)
+		{
+			var item = new Item(itemId);
+			item.MetaData1.SetInt("FORMID", formId);
+			item.OptionInfo.DurabilityMax = useCount * 1000; // DurabilityMax overwritten to avoid clamping.
+			item.Durability = item.OptionInfo.DurabilityMax;
+
+			return item;
+		}
+
+		/// <summary>
 		/// Returns true if item has the given flags.
 		/// </summary>
 		/// <param name="flags"></param>


### PR DESCRIPTION
(Also applies to blacksmith manuals.)

Sample usage:
```csharp
// Apprentice Sewing Pattern - Mongo Traveler Suit (F), 40 uses
npc.Player.GiveItem(Item.CreatePattern(60600, 10107, 40));
```

re: https://github.com/aura-project/aura/pull/376/files#r74115977 
Is this what you meant, @exectails ?

> Data is the global data, by modifying it you modify the durability of all future items with that item id.

Durability is now modified through `Item.OptionInfo` . When I spawn additional patterns, default durability is untouched.