### PR TITLE
Add Kristell PTJ

### DIFF
--- a/system/scripts/npcs/dunbarton/kristell.cs
+++ b/system/scripts/npcs/dunbarton/kristell.cs
@@ -120,10 +120,6 @@ public class KristellScript : NpcScript
 				ModifyRelation(Random(2), 0, Random(3));
 				break;
 
-			case "about_arbeit":
-				Msg("Unimplemented");
-				break;
-
 			case "shop_misc":
 				GiveKeyword("musicsheet");
 				Msg("Looking for the General Shop?<br/>The General Shop is down this way.<br/>Go down to the Square from here<br/>and look for Walter.");

--- a/system/scripts/quests/ptj/church_kristell.cs
+++ b/system/scripts/quests/ptj/church_kristell.cs
@@ -1,0 +1,212 @@
+#region TEMP_NOTES
+// If you see this region in a pull request, 
+// **I contain undefined values and should not be merged into master!**
+
+// Class name resolver - go go gadget intellisense
+using Aura.Mabi;
+using Aura.Mabi.Const;
+using System.Threading.Tasks;
+using Aura.Channel.Scripting.Scripts;
+// Temporarily place this file under ChannelServer.csproj to resolve rest of dependencies
+#endregion
+
+//--- Aura Script -----------------------------------------------------------
+// Kristell's Church Part-Time Job
+//--- Description -----------------------------------------------------------
+// All quests used by the PTJ, and a script to handle the PTJ via hooks.
+//---------------------------------------------------------------------------
+
+public class KristellPtjScript : GeneralScript
+{
+	const PtjType JobType = PtjType.Church;
+
+	const int Start = 12;
+	const int Report = 16;
+	const int Deadline = 21;
+	const int PerDay = 10;
+
+	int remaining = PerDay;
+
+	readonly int[] QuestIds = new int[]
+	{
+		?
+	};
+
+	public override void Load()
+	{
+		AddHook("_kristell", "after_intro", AfterIntro);
+		AddHook("_kristell", "before_keywords", BeforeKeywords);
+	}
+
+	public async Task<HookResult> AfterIntro(NpcScript npc, params object[] args)
+	{
+		// Call PTJ method after intro if it's time to report
+		if (npc.DoingPtjForNpc() && npc.ErinnHour(Report, Deadline))
+		{
+			await AboutArbeit(npc);
+			return HookResult.Break;
+		}
+
+		return HookResult.Continue;
+	}
+
+	[On("ErinnMidnightTick")]
+	private void OnErinnMidnightTick(ErinnTime time)
+	{
+		// Reset available jobs
+		remaining = PerDay;
+	}
+
+	public async Task<HookResult> BeforeKeywords(NpcScript npc, params object[] args)
+	{
+		var keyword = args[0] as string;
+
+		// Hook PTJ keyword
+		if (keyword == "about_arbeit")
+		{
+			await AboutArbeit(npc);
+			await npc.Conversation();
+			npc.End();
+
+			return HookResult.End;
+		}
+
+		return HookResult.Continue;
+	}
+
+	public async Task AboutArbeit(NpcScript npc)
+	{
+		// Check if already doing another PTJ
+		if (npc.DoingPtjForOtherNpc())
+		{
+			npc.Msg(L("The Church also needs workers.<br/>Please pay a visit here once you finish the current task."));
+			return;
+		}
+
+		// Check if PTJ is in progress
+		if (npc.DoingPtjForNpc())
+		{
+			var result = npc.GetPtjResult();
+
+			// Check if report time
+			if (!npc.ErinnHour(Report, Deadline))
+			{
+				if (result == QuestResult.Perfect)
+				{
+					npc.Msg(L("You have finished already?<br/>It is a little too early, so would you mind returning later?"));
+				}
+				else
+				{
+					npc.Msg(L("I trust that the assigned task is going well?<br/>The deadline is not past yet, so please do your best."));
+				}
+				return;
+			}
+
+			// Report?
+			npc.Msg(L("It seems that you have completed the given task.<br/>If you would like, we can call it a day here."),
+				npc.Button(L("Report Now"), "@report"),
+				npc.Button(L("Report Later"), "@later")
+				);
+
+			if (await npc.Select() != "@report")
+			{
+				npc.Msg(L("If not right now, please make sure to report to me before the deadline.<br/>You have to at least report back to me even if you do not completely finish your task."));
+				return;
+			}
+
+			// Nothing done
+			if (result == QuestResult.None)
+			{
+				npc.GiveUpPtj();
+
+				npc.Msg(npc.FavorExpression(), L("Oh, good heavens!<br/><username/>, I trusted you with this and this is all you have done. How disappointing.<br/>I cannot pay you for this."));
+				npc.ModifyRelation(0, -Random(3), 0);
+			}
+			// Low~Perfect result
+			else
+			{
+				npc.Msg(L("Mmm? I did not know you would do such a good job.<br/>You are a very meticulous worker, <username/>.<br/>I know this does not do justice for the excellent work you have done, but<br/>I have prepared a few things as a token of my gratitude. Please, take your pick."),
+					npc.Button(L("Report Later"), "@later"),
+					npc.PtjReport(result)
+					);
+				var reply = await npc.Select();
+
+				// Report later
+				if (!reply.StartsWith("@reward:"))
+				{
+					npc.Msg(npc.FavorExpression(), L("You seem to be busy all the time, <username/>."));
+					return;
+				}
+
+				// Complete
+				npc.CompletePtj(reply);
+				remaining--;
+
+				// Result msg
+				if (result == QuestResult.Perfect)
+				{
+					npc.Msg(npc.FavorExpression(), L("Great! You have done very well.<br/>Here is the Holy Water as promised."));
+					npc.ModifyRelation(0, Random(3), 0);
+				}
+				else if (result == QuestResult.Mid)
+				{
+					npc.Msg(npc.FavorExpression(), L("Thank you for your help.<br/>But, it is a little less than what was asked for.<br/>Anyway, I will pay you for what has been completed."));
+					npc.ModifyRelation(0, Random(1), 0);
+				}
+				else if (result == QuestResult.Low)
+				{
+					npc.Msg(npc.FavorExpression(), L("Hmm. You have not adequately completed your work.<br/>Did you not have enough time?<br/>I cannot give you the Holy Water, then."));
+					npc.ModifyRelation(0, -Random(2), 0);
+				}
+			}
+			return;
+		}
+
+		// Check if PTJ time
+		if (!npc.ErinnHour(Start, Deadline))
+		{
+			npc.Msg(L("Oh, no. It is not time for Church duties yet.<br/>Would you return later?"));
+			return;
+		}
+
+		// Check if not done today and if there are jobs remaining
+		if (!npc.CanDoPtj(JobType, remaining))
+		{
+			npc.Msg(L("Today's work has been completed.<br/>Only one task is given to one person per day.<br/>Please return tomorrow."));
+			return;
+		}
+
+		// Offer PTJ
+		var randomPtj = npc.RandomPtj(JobType, QuestIds);
+		var msg = "";
+
+		if (npc.GetPtjDoneCount(JobType) == 0)
+			msg = L("(missing): first time worker PTJ inquiry");
+		else
+			msg = L("Do you want to work at the Church again today?<br/>Please take a look at the work details before you decide.");
+
+		npc.Msg(msg, npc.PtjDesc(randomPtj,
+			L("Kristell's Church Part-Time Job"),
+			L("Looking for help with delivering goods to Church."),
+			PerDay, remaining, npc.GetPtjDoneCount(JobType)));
+
+		if (await npc.Select() == "@accept")
+		{
+			if (npc.GetPtjDoneCount(JobType) == 0)
+				msg = L("(missing): first time accepting PTJ offer");
+			else
+				msg = L("Thank you.<br/>I hope you finish it in time.");
+
+			npc.StartPtj(randomPtj);
+		}
+		else
+		{
+			if (npc.GetPtjDoneCount(JobType) == 0)
+				msg = L("(missing): first time declining PTJ offer");
+			else
+				msg = L("Are you busy with something else?<br/>If not today, please give me a hand later.");
+		}
+	}
+}
+
+Unimplemented: QuestScripts

--- a/system/scripts/quests/ptj/church_kristell.cs
+++ b/system/scripts/quests/ptj/church_kristell.cs
@@ -197,18 +197,18 @@ public class KristellPtjScript : GeneralScript
 		if (await npc.Select() == "@accept")
 		{
 			if (npc.GetPtjDoneCount(JobType) == 0)
-				msg = L("(missing): first time accepting PTJ offer");
+				npc.Msg(L("(missing): first time accepting PTJ offer"));
 			else
-				msg = L("Thank you.<br/>I hope you finish it in time.");
+				npc.Msg(L("Thank you.<br/>I hope you finish it in time."));
 
 			npc.StartPtj(randomPtj);
 		}
 		else
 		{
 			if (npc.GetPtjDoneCount(JobType) == 0)
-				msg = L("(missing): first time declining PTJ offer");
+				npc.Msg(L("(missing): first time declining PTJ offer"));
 			else
-				msg = L("Are you busy with something else?<br/>If not today, please give me a hand later.");
+				npc.Msg(L("Are you busy with something else?<br/>If not today, please give me a hand later."));
 		}
 	}
 }

--- a/system/scripts/quests/ptj/church_kristell.cs
+++ b/system/scripts/quests/ptj/church_kristell.cs
@@ -280,8 +280,17 @@ public abstract class KristellPtjBaseScript : QuestScript
 
 public abstract class KristellPotatoPtjBaseScript : KristellPtjBaseScript
 {
-	protected override string QuestDescription { get { return string.Format(L("This job is to harvest vegetables from the farmland. Today, dig up [{0} Potatoes]. Use a weeding hoe to gather potatoes from the fields around town."), L(ItemCount.ToString())); } }
-	protected override string ObjectiveDescription { get { return string.Format(L("Harvest {0} Potatoes"), L(ItemCount.ToString())); } }
+	protected override string QuestDescription
+	{
+		get
+		{
+			return string.Format(LN(
+				"This job is to harvest vegetables from the farmland. Today, dig up [{0} Potato]. Use a weeding hoe to gather potatoes from the fields around town.",
+				"This job is to harvest vegetables from the farmland. Today, dig up [{0} Potatoes]. Use a weeding hoe to gather potatoes from the fields around town.",
+				ItemCount), ItemCount);
+		}
+	}
+	protected override string ObjectiveDescription { get { return string.Format(LN("Harvest {0} Potato", "Harvest {0} Potatoes", ItemCount), ItemCount); } }
 	protected override int ItemId { get { return 50010; } }
 }
 
@@ -308,8 +317,17 @@ public class KristellPotatoAdvPtjScript : KristellPotatoPtjBaseScript
 
 public abstract class KristellApplePtjBaseScript : KristellPtjBaseScript
 {
-	protected override string QuestDescription { get { return string.Format(L("This job is to gather fruit from the outskirts of the town. Today, gather [{0} Apples]. Gather apples from apple trees on the outskirts of the town."), L(ItemCount.ToString())); } }
-	protected override string ObjectiveDescription { get { return string.Format(L("Harvest {0} Apples"), L(ItemCount.ToString())); } }
+	protected override string QuestDescription
+	{
+		get
+		{
+			return string.Format(LN(
+				"This job is to gather fruit from the outskirts of the town. Today, gather [{0} Apple]. Gather apples from apple trees on the outskirts of the town.",
+				"This job is to gather fruit from the outskirts of the town. Today, gather [{0} Apples]. Gather apples from apple trees on the outskirts of the town.",
+				ItemCount), ItemCount);
+		}
+	}
+	protected override string ObjectiveDescription { get { return string.Format(LN("Harvest {0} Apple", "Harvest {0} Apples", ItemCount), ItemCount); } }
 	protected override int ItemId { get { return 50003; } }
 }
 

--- a/system/scripts/scripts_quests.txt
+++ b/system/scripts/scripts_quests.txt
@@ -68,6 +68,7 @@ quests/beginner_uladh/hunting/1000060_hunting_ogre_warrior.cs
 
 // Part-Time Jobs
 quests/ptj/church_endelyon.cs
+quests/ptj/church_kristell.cs
 quests/ptj/grocery_caitin.cs
 quests/ptj/healer_dilys.cs
 quests/ptj/inn_piaras.cs


### PR DESCRIPTION
Both this and Endelyon's PTJ scripts share quest IDs for egg collecting (/5021[036]5/), so this script must load last. If, in the future, script loading were to become multithreaded, this might be a problem.

The following dialogue is missing: 
* First-time worker inquiry
* First-time worker reject PTJ
* First-time worker accept PTJ

ref: #237 