### PR TITLE
Implement quest OnComplete(), #414 Fix - Stewart PTJ: Remove lingering books on quest completion

### DIFF
--- a/src/ChannelServer/Scripting/Scripts/QuestScript.cs
+++ b/src/ChannelServer/Scripting/Scripts/QuestScript.cs
@@ -613,6 +613,10 @@ namespace Aura.Channel.Scripting.Scripts
 		{
 		}
 
+		public virtual void OnComplete(Creature creature)
+		{
+		}
+
 		// Where the magic happens~
 		// ------------------------------------------------------------------
 

--- a/src/ChannelServer/World/Entities/Creatures/CreatureQuests.cs
+++ b/src/ChannelServer/World/Entities/Creatures/CreatureQuests.cs
@@ -419,6 +419,9 @@ namespace Aura.Channel.World.Entities.Creatures
 				}
 
 				ChannelServer.Instance.Events.OnPlayerCompletesQuest(_creature, quest.Id);
+
+				// Complete event
+				quest.Data.OnComplete(_creature);
 			}
 			return success;
 		}

--- a/system/scripts/quests/ptj/library_stewart.cs
+++ b/system/scripts/quests/ptj/library_stewart.cs
@@ -357,18 +357,18 @@ public abstract class StewartVarLibraryPtjBaseScript : QuestScript
 
 	/// <summary>
 	/// Removes other quest items for PTJs involving more than one book.
-	/// <para>To be called manually.</para>
 	/// </summary>
-	/// <param name="player"></param>
+	/// <param name="creature"></param>
 	/// <remarks>
-	/// Hotfix #414: Stewart's PtjScripts manually removes items OnQuestComplete.
+	/// Fix #414: Lingering books on quest completion for Stewart PTJ
 	/// This might be removed when "any order" quest objective completion is implemented.
 	/// </remarks>
-	public void OnQuestComplete(Creature player)
+	public override void OnComplete(Creature creature)
 	{
-		// Skip last book; already taken care of by CreatureQuests.Complete(Quest, int, bool) .
+		// Remove all books except the last one;
+		// the last book is already taken care of automatically by CreatureQuests.Complete(Quest, int, bool) .
 		for (int i = NpcBookPairs.Length - 2; i >= 0; --i)
-			player.RemoveItem(NpcBookPairs[i].ItemId);
+			creature.RemoveItem(NpcBookPairs[i].ItemId);
 	}
 
 	private NpcScriptHook GenerateBookcaseAfterIntroHook(string objectiveIdent, int bookItemId)

--- a/system/scripts/quests/ptj/library_stewart.cs
+++ b/system/scripts/quests/ptj/library_stewart.cs
@@ -159,6 +159,13 @@ public class StewartPtjScript : GeneralScript
 				return;
 			}
 
+			// Hotfix #414: Stewart's base PtjScript manually removes items OnQuestComplete.
+			var qs = npc.Player.Quests.GetPtjQuest().Data as StewartVarLibraryPtjBaseScript;
+			if (qs == null)
+				Log.Error("Stewart PTJ Script: Unable to call OnQuestComplete() for quest ID {0}.", qs.Id);
+			else
+				qs.OnQuestComplete(npc.Player);
+
 			// Nothing done
 			if (result == QuestResult.None)
 			{
@@ -353,6 +360,22 @@ public abstract class StewartVarLibraryPtjBaseScript : QuestScript
 		}
 
 		AddRewards();
+	}
+
+	/// <summary>
+	/// Removes other quest items for PTJs involving more than one book.
+	/// <para>To be called manually.</para>
+	/// </summary>
+	/// <param name="player"></param>
+	/// <remarks>
+	/// Hotfix #414: Stewart's PtjScripts manually removes items OnQuestComplete.
+	/// This might be removed when "any order" quest objective completion is implemented.
+	/// </remarks>
+	public void OnQuestComplete(Creature player)
+	{
+		// Skip last book; already taken care of by CreatureQuests.Complete(Quest, int, bool) .
+		for (int i = NpcBookPairs.Length - 2; i >= 0; --i)
+			player.RemoveItem(NpcBookPairs[i].ItemId);
 	}
 
 	private NpcScriptHook GenerateBookcaseAfterIntroHook(string objectiveIdent, int bookItemId)

--- a/system/scripts/quests/ptj/library_stewart.cs
+++ b/system/scripts/quests/ptj/library_stewart.cs
@@ -159,13 +159,6 @@ public class StewartPtjScript : GeneralScript
 				return;
 			}
 
-			// Hotfix #414: Stewart's base PtjScript manually removes items OnQuestComplete.
-			var qs = npc.Player.Quests.GetPtjQuest().Data as StewartVarLibraryPtjBaseScript;
-			if (qs == null)
-				Log.Error("Stewart PTJ Script: Unable to call OnQuestComplete() for quest ID {0}.", qs.Id);
-			else
-				qs.OnQuestComplete(npc.Player);
-
 			// Nothing done
 			if (result == QuestResult.None)
 			{


### PR DESCRIPTION
Quest objective order and types have been retained.

Last book to collect was skipped in this hotfix so as to avoid removing two books (if the player were to be holding onto two for some reason).