### PR TITLE
Fixup: Bangor PTJs, Add Blacksmithing to 'allskills' command

### DIFF
--- a/src/ChannelServer/Util/GmCommands.cs
+++ b/src/ChannelServer/Util/GmCommands.cs
@@ -1382,7 +1382,7 @@ namespace Aura.Channel.Util
 				SkillId.Counterattack, SkillId.CriticalHit, SkillId.Defense, SkillId.FinalHit, SkillId.MagnumShot, SkillId.RangedAttack,
 				SkillId.Smash, SkillId.Windmill, SkillId.SupportShot, SkillId.ArrowRevolver2,
 
-				SkillId.Campfire, SkillId.FirstAid, SkillId.Fishing, SkillId.Handicraft, SkillId.Herbalism, SkillId.PotionMaking,
+				SkillId.Blacksmithing, SkillId.Campfire, SkillId.FirstAid, SkillId.Fishing, SkillId.Handicraft, SkillId.Herbalism, SkillId.PotionMaking,
 				SkillId.ProductionMastery, SkillId.Refining, SkillId.Rest, SkillId.Tailoring, SkillId.Weaving,
 
 				SkillId.Firebolt, SkillId.Healing, SkillId.Icebolt, SkillId.Lightningbolt, SkillId.ManaShield, SkillId.Meditation, SkillId.SilentMove,

--- a/system/scripts/quests/ptj/blacksmith_elen.cs
+++ b/system/scripts/quests/ptj/blacksmith_elen.cs
@@ -4,9 +4,6 @@
 // All quests used by the PTJ, and a script to handle the PTJ via hooks.
 //--- Notes -----------------------------------------------------------------
 // The following dialogue is missing:
-// * first time worker PTJ inquiry
-// * first time accepting PTJ offer
-// * first time declining PTJ offer
 // * 1-star PTJ turn in response
 // * 3-star PTJ turn in response
 //---------------------------------------------------------------------------
@@ -175,7 +172,7 @@ public class ElenPtjScript : GeneralScript
 		var msg = "";
 
 		if (npc.GetPtjDoneCount(JobType) == 0)
-			npc.Msg(L("Are you interested in some part-time work at the Bangor Blacksmith's Shop?<br/>If you complete the work before<br/>the deadline, I'll pay you."));
+			msg = L("Are you interested in some part-time work at the Bangor Blacksmith's Shop?<br/>If you complete the work before<br/>the deadline, I'll pay you."));
 		else
 			msg = L("Would you like to see today's work agenda?");
 

--- a/system/scripts/quests/ptj/church_comgan.cs
+++ b/system/scripts/quests/ptj/church_comgan.cs
@@ -2,11 +2,6 @@
 // Comgan's Monster-Hunting Part-Time Job
 //--- Description -----------------------------------------------------------
 // All quests used by the PTJ, and a script to handle the PTJ via hooks.
-//--- Notes -----------------------------------------------------------------
-// The following dialogue is missing:
-// * first time worker PTJ inquiry
-// * first time accepting PTJ offer
-// * first time declining PTJ offer
 //---------------------------------------------------------------------------
 
 public class ComganPtjScript : GeneralScript
@@ -173,7 +168,7 @@ public class ComganPtjScript : GeneralScript
 		var msg = "";
 
 		if (npc.GetPtjDoneCount(JobType) == 0)
-			npc.Msg(L("As you can see, I am in need of financial assistance,<br/>not in a position to help financially.<br/>But if you help with the tasks, I can at least give you some holy water."));
+			msg = L("As you can see, I am in need of financial assistance,<br/>not in a position to help financially.<br/>But if you help with the tasks, I can at least give you some holy water.");
 		else
 			msg = L("Do you need holy water again today?");
 
@@ -194,7 +189,7 @@ public class ComganPtjScript : GeneralScript
 		else
 		{
 			if (npc.GetPtjDoneCount(JobType) == 0)
-				npc.Msg(L("Don't like the given work, do you?<br/>"));
+				npc.Msg(L("Don't like the given work, do you?"));
 			else
 				npc.Msg(L("I am sorry, but if you won't help with the tasks,<br/>I cannot really help you, either."));
 		}

--- a/system/scripts/quests/ptj/stope_sion.cs
+++ b/system/scripts/quests/ptj/stope_sion.cs
@@ -48,7 +48,7 @@ public class SionPtjScript : GeneralScript
 
 			npc.Player.Inventory.Remove(64002, itemCount);
 			npc.Notice(L("You have given Iron Ore to Sion."));
-			npc.Msg(LN("(Gave Sion {0} Iron Ore)", "(Gave Sion {0} Iron Ore)", itemCount));
+			npc.Msg(string.Format(LN("(Gave Sion {0} Iron Ore)", "(Gave Sion {0} Iron Ore)", itemCount), itemCount));
 		}
 
 		// Call PTJ method after intro if it's time to report
@@ -224,10 +224,10 @@ public abstract class SionMinePtjBaseScript : QuestScript
 	{
 		SetId(QuestId);
 		SetName(L("Iron Ore-Mining Part-time Job"));
-		SetDescription(LN(
+		SetDescription(string.Format(LN(
 			"This task involves going into the mines to mine out Iron Ore. Today, the task is mining out [{0} Iron Ore]. Mining out the ore will require a Pickaxe, so make sure to bring that before heading over to the mines.",
 			"This task involves going into the mines to mine out Iron Ore. Today, the task is mining out [{0} Iron Ore]. Mining out the ore will require a Pickaxe, so make sure to bring that before heading over to the mines.",
-			ItemCount
+			ItemCount), ItemCount
 			));
 
 		if (IsEnabled("QuestViewRenewal"))
@@ -238,8 +238,8 @@ public abstract class SionMinePtjBaseScript : QuestScript
 		SetLevel(QuestLevel);
 		SetHours(start: 10, report: 15, deadline: 23);
 
-		AddObjective("ptj1", LN("Mine {0} Iron Ore", "Mine {0} Iron Ore", ItemCount), 0, 0, 0, Gather(64002, ItemCount));
-		AddObjective("ptj2", LN("Deliver {0} Iron Ore to Sion", "Deliver {0} Iron Ore to Sion", ItemCount), 0, 0, 0, Deliver(64002, "_sion"));
+		AddObjective("ptj1", string.Format(LN("Mine {0} Iron Ore", "Mine {0} Iron Ore", ItemCount), ItemCount), 0, 0, 0, Gather(64002, ItemCount));
+		AddObjective("ptj2", string.Format(LN("Deliver {0} Iron Ore to Sion", "Deliver {0} Iron Ore to Sion", ItemCount), ItemCount), 0, 0, 0, Deliver(64002, "_sion"));
 
 		// Sion's AfterIntro is handled above, as we have to deliver the ore to him
 		// before he asks us about the PTJ.


### PR DESCRIPTION
- Comgan, Elen PTJ: Removed extraneous blank message when accepting a quest for the first time.
- Sion PTJ: Properly implemented parametrised strings.
- Add Blacksmithing to 'allskills' command _(Accidentally left out?)_